### PR TITLE
feat: 구글 oauth 계정 관리 기능 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
     ```bash
     cd apps/server
     ./gradlew bootRun
+    ./gradlew bootRun --args='--spring.profiles.active=dev' # dev profile
     ```
 
 - 웹 빌드 및 실행

--- a/apps/server/src/main/java/com/skkil/sync/config/SecurityConfig.java
+++ b/apps/server/src/main/java/com/skkil/sync/config/SecurityConfig.java
@@ -1,0 +1,26 @@
+package com.skkil.sync.config;
+
+import com.skkil.sync.user.service.oauth2.CustomOidcUserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  private final CustomOidcUserService customOidcUserService;
+
+  @Bean
+  SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http.oauth2Login(
+        oauth2 ->
+            oauth2.userInfoEndpoint(userInfo -> userInfo.oidcUserService(customOidcUserService)));
+
+    return http.build();
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/user/constant/OAuth2Provider.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/constant/OAuth2Provider.java
@@ -18,6 +18,6 @@ public enum OAuth2Provider {
       }
     }
 
-    throw new IllegalArgumentException("Unknown OAuthProvider ID: " + id);
+    throw new IllegalArgumentException("Unknown OAuth2 provider ID: " + id);
   }
 }

--- a/apps/server/src/main/java/com/skkil/sync/user/constant/OAuth2Provider.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/constant/OAuth2Provider.java
@@ -1,0 +1,23 @@
+package com.skkil.sync.user.constant;
+
+import lombok.Getter;
+
+public enum OAuth2Provider {
+  GOOGLE("google");
+
+  @Getter private final String id;
+
+  private OAuth2Provider(String id) {
+    this.id = id;
+  }
+
+  public static OAuth2Provider from(String id) {
+    for (OAuth2Provider provider : values()) {
+      if (provider.getId().equals(id)) {
+        return provider;
+      }
+    }
+
+    throw new IllegalArgumentException("Unknown OAuthProvider ID: " + id);
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/user/model/User.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/model/User.java
@@ -2,12 +2,16 @@ package com.skkil.sync.user.model;
 
 import com.skkil.sync.common.domain.BaseEntity;
 import com.skkil.sync.user.constant.Role;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -41,6 +45,12 @@ public class User extends BaseEntity {
 
   @Column(name = "deleted_at", nullable = true)
   private Instant deletedAt;
+
+  @OneToMany(
+      mappedBy = "user",
+      cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
+      orphanRemoval = true)
+  private List<UserOAuth2Account> oAuth2Accounts = new ArrayList<>();
 
   protected User() {}
 

--- a/apps/server/src/main/java/com/skkil/sync/user/model/UserOAuth2Account.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/model/UserOAuth2Account.java
@@ -1,0 +1,43 @@
+package com.skkil.sync.user.model;
+
+import com.skkil.sync.common.domain.BaseEntity;
+import com.skkil.sync.user.constant.OAuth2Provider;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table(
+    name = "user_oauth2_accounts",
+    uniqueConstraints = {@UniqueConstraint(columnNames = {"user_id", "oauth_provider"})})
+@Getter
+public class UserOAuth2Account extends BaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "oauth_provider", nullable = false)
+  private OAuth2Provider oAuth2Provider;
+
+  @Column(name = "oauth_provider_user_id", nullable = false, length = 255)
+  private String oAuth2ProviderUserId;
+
+  protected UserOAuth2Account() {}
+
+  @Builder
+  public UserOAuth2Account(User user, OAuth2Provider oAuth2Provider, String oAuth2ProviderUserId) {
+    this.user = user;
+    this.oAuth2Provider = oAuth2Provider;
+    this.oAuth2ProviderUserId = oAuth2ProviderUserId;
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/user/repository/UserRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/repository/UserRepository.java
@@ -1,6 +1,12 @@
 package com.skkil.sync.user.repository;
 
 import com.skkil.sync.user.model.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-public interface UserRepository extends JpaRepository<User, Long> {}
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  @Query("SELECT u FROM User u LEFT JOIN FETCH u.oAuth2Accounts WHERE u.email = :email")
+  Optional<User> findByEmailWithOAuthAccounts(String email);
+}

--- a/apps/server/src/main/java/com/skkil/sync/user/service/oauth2/CustomOidcUserService.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/service/oauth2/CustomOidcUserService.java
@@ -39,6 +39,7 @@ public class CustomOidcUserService extends OidcUserService {
   @Transactional
   public User processOAuth2User(OAuth2Provider provider, OidcUser oidcUser) {
     String email = oidcUser.getEmail();
+    String fullName = oidcUser.getFullName() == null ? "" : oidcUser.getFullName();
 
     User user =
         userRepository
@@ -46,7 +47,7 @@ public class CustomOidcUserService extends OidcUserService {
             .orElseGet(
                 () -> {
                   log.debug("User not found with email: {}. Creating new user.", email);
-                  return User.builder().email(email).fullName(oidcUser.getFullName()).build();
+                  return User.builder().email(email).fullName(fullName).build();
                 });
 
     if (user.getOAuth2Accounts().stream()

--- a/apps/server/src/main/java/com/skkil/sync/user/service/oauth2/CustomOidcUserService.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/service/oauth2/CustomOidcUserService.java
@@ -1,0 +1,66 @@
+package com.skkil.sync.user.service.oauth2;
+
+import com.skkil.sync.user.constant.OAuth2Provider;
+import com.skkil.sync.user.model.User;
+import com.skkil.sync.user.model.UserOAuth2Account;
+import com.skkil.sync.user.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+public class CustomOidcUserService extends OidcUserService {
+
+  private final UserRepository userRepository;
+
+  public CustomOidcUserService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  @Override
+  public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
+    String registrationId = userRequest.getClientRegistration().getRegistrationId();
+    OAuth2Provider provider = OAuth2Provider.from(registrationId);
+    log.debug("Loading OIDC user from provider: {}", provider);
+
+    OidcUser oidcUser = super.loadUser(userRequest);
+    log.debug("OIDC user loaded: {}", oidcUser.getEmail());
+
+    processOAuth2User(provider, oidcUser);
+
+    return oidcUser;
+  }
+
+  @Transactional
+  public User processOAuth2User(OAuth2Provider provider, OidcUser oidcUser) {
+    String email = oidcUser.getEmail();
+
+    User user =
+        userRepository
+            .findByEmailWithOAuthAccounts(email)
+            .orElseGet(
+                () -> {
+                  log.debug("User not found with email: {}. Creating new user.", email);
+                  return User.builder().email(email).fullName(oidcUser.getFullName()).build();
+                });
+
+    if (user.getOAuth2Accounts().stream()
+        .noneMatch(account -> provider.equals(account.getOAuth2Provider()))) {
+      log.debug("Linking OAuth2 provider {} to user with email: {}", provider, user.getEmail());
+      user.getOAuth2Accounts()
+          .add(
+              UserOAuth2Account.builder()
+                  .user(user)
+                  .oAuth2Provider(provider)
+                  .oAuth2ProviderUserId(oidcUser.getSubject())
+                  .build());
+    }
+
+    return userRepository.save(user);
+  }
+}

--- a/apps/server/src/main/resources/application-dev.yaml
+++ b/apps/server/src/main/resources/application-dev.yaml
@@ -1,0 +1,3 @@
+logging:
+  level:
+    com.skkil: TRACE

--- a/apps/server/src/main/resources/application.yaml
+++ b/apps/server/src/main/resources/application.yaml
@@ -30,8 +30,3 @@ spring:
               - openid
               - profile
               - email
-
-logging:
-  level:
-    org:
-      skkil: TRACE

--- a/apps/server/src/main/resources/application.yaml
+++ b/apps/server/src/main/resources/application.yaml
@@ -2,6 +2,9 @@ spring:
   application:
     name: sync
 
+  config:
+    import: optional:file:.env[.properties]
+
   jpa:
     open-in-view: false
     hibernate:
@@ -15,3 +18,20 @@ spring:
     store-type: jdbc
     jdbc:
       initialize-schema: always
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${OAUTH2_CLIENT_REGISTRATION_GOOGLE_CLIENT_ID}
+            client-secret: ${OAUTH2_CLIENT_REGISTRATION_GOOGLE_CLIENT_SECRET}
+            scope:
+              - openid
+              - profile
+              - email
+
+logging:
+  level:
+    org:
+      skkil: TRACE

--- a/apps/server/src/main/resources/db/changelog/changesets/00003-create-table-user-oauth2-accounts.yaml
+++ b/apps/server/src/main/resources/db/changelog/changesets/00003-create-table-user-oauth2-accounts.yaml
@@ -1,0 +1,52 @@
+databaseChangeLog:
+  - changeSet:
+      id: 00003-create-table-user-oauth2-accounts
+      author: hyoungjoojin
+      preConditions:
+        - not:
+            tableExists:
+              tableName: user_oauth2_accounts
+      changes:
+        - createTable:
+            tableName: user_oauth2_accounts
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  defaultValueComputed: CURRENT_TIMESTAMP
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP
+                  defaultValueComputed: CURRENT_TIMESTAMP
+              - column:
+                  name: user_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: oauth_provider
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: oauth_provider_user_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: user_oauth2_accounts
+            baseColumnNames: user_id
+            referencedTableName: users
+            referencedColumnNames: id
+            constraintName: fk_user_oauth2_accounts_user_id
+            onDelete: CASCADE
+        - addUniqueConstraint:
+            tableName: user_oauth2_accounts
+            columnNames: user_id, oauth_provider
+            constraintName: uq_user_oauth2_accounts_user_id_oauth_provider

--- a/apps/server/src/test/java/com/skkil/sync/user/repository/UserRepositoryTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/user/repository/UserRepositoryTests.java
@@ -83,6 +83,7 @@ class UserRepositoryTests {
   }
 
   @Test
+  @DisplayName("OAuth2Account 추가 시 정상적으로 추가됨")
   void addOAuth2Account_accountAddedSuccessfully() {
     User user = User.builder().email("user@email.com").fullName("Full Name").build();
     assertThat(user.getOAuth2Accounts()).isNotNull().isEmpty();

--- a/apps/server/src/test/java/com/skkil/sync/user/repository/UserRepositoryTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/user/repository/UserRepositoryTests.java
@@ -5,7 +5,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.skkil.sync.config.JpaConfig;
 import com.skkil.sync.config.TestcontainersConfig;
+import com.skkil.sync.user.constant.OAuth2Provider;
 import com.skkil.sync.user.model.User;
+import com.skkil.sync.user.model.UserOAuth2Account;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,6 +38,13 @@ class UserRepositoryTests {
     User foundUser = userRepository.findById(user.getId()).orElseThrow();
     assertThat(foundUser.getCreatedAt()).isNotNull();
     assertThat(foundUser.getUpdatedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("User 생성 시 oAuth2Accounts 필드가 null이 아님")
+  void createUser_oAuth2AccountsIsNotNull() {
+    User user = User.builder().email("user@email.com").fullName("Full Name").build();
+    assertThat(user.getOAuth2Accounts()).isNotNull();
   }
 
   @Test
@@ -71,5 +80,29 @@ class UserRepositoryTests {
 
     User foundUser = userRepository.findById(user.getId()).orElseThrow();
     assertThat(foundUser.getDeletedAt()).isNotNull();
+  }
+
+  @Test
+  void addOAuth2Account_accountAddedSuccessfully() {
+    User user = User.builder().email("user@email.com").fullName("Full Name").build();
+    assertThat(user.getOAuth2Accounts()).isNotNull().isEmpty();
+
+    user.getOAuth2Accounts()
+        .add(
+            UserOAuth2Account.builder()
+                .user(user)
+                .oAuth2Provider(OAuth2Provider.GOOGLE)
+                .oAuth2ProviderUserId("google-user-id")
+                .build());
+    user = userRepository.save(user);
+
+    User foundUser = userRepository.findByEmailWithOAuthAccounts(user.getEmail()).orElseThrow();
+    assertThat(foundUser.getOAuth2Accounts())
+        .hasSize(1)
+        .allSatisfy(
+            account -> {
+              assertThat(account.getOAuth2Provider()).isEqualTo(OAuth2Provider.GOOGLE);
+              assertThat(account.getOAuth2ProviderUserId()).isEqualTo("google-user-id");
+            });
   }
 }

--- a/apps/server/src/test/java/com/skkil/sync/user/service/oauth2/CustomOidcUserServiceTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/user/service/oauth2/CustomOidcUserServiceTests.java
@@ -3,7 +3,6 @@ package com.skkil.sync.user.service.oauth2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/apps/server/src/test/java/com/skkil/sync/user/service/oauth2/CustomOidcUserServiceTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/user/service/oauth2/CustomOidcUserServiceTests.java
@@ -1,0 +1,135 @@
+package com.skkil.sync.user.service.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.skkil.sync.user.constant.OAuth2Provider;
+import com.skkil.sync.user.model.User;
+import com.skkil.sync.user.model.UserOAuth2Account;
+import com.skkil.sync.user.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+@ExtendWith(MockitoExtension.class)
+public class CustomOidcUserServiceTests {
+
+  @InjectMocks private CustomOidcUserService customOidcUserService;
+
+  @Mock private UserRepository userRepository;
+
+  @Test
+  @DisplayName("loadUser 시 존재하지 않는 OAuth2Provider면 IllegalArgumentException 발생")
+  void loadUser_oAuth2ProviderDoesNotExist_throwIllegalArgumentException() {
+    OidcUserRequest userRequest = mock(OidcUserRequest.class);
+    ClientRegistration clientRegistration = mock(ClientRegistration.class);
+
+    when(clientRegistration.getRegistrationId()).thenReturn("invalid_provider");
+    when(userRequest.getClientRegistration()).thenReturn(clientRegistration);
+
+    assertThatThrownBy(() -> customOidcUserService.loadUser(userRequest))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("processOAuth2User 시 계정이 없으면 새 계정 생성")
+  void processOAuth2User_noAccountExists_createAccount() {
+    OidcUser oidcUser = mock(OidcUser.class);
+    OAuth2Provider provider = OAuth2Provider.GOOGLE;
+
+    when(oidcUser.getEmail()).thenReturn("user@email.com");
+    when(oidcUser.getFullName()).thenReturn("Test User");
+    when(oidcUser.getSubject()).thenReturn("provider-user-id");
+
+    when(userRepository.findByEmailWithOAuthAccounts("user@email.com"))
+        .thenReturn(Optional.empty());
+    when(userRepository.save(any(User.class))).thenAnswer(i -> i.getArgument(0));
+
+    User result = customOidcUserService.processOAuth2User(provider, oidcUser);
+
+    assertThat(result)
+        .hasFieldOrPropertyWithValue("email", "user@email.com")
+        .hasFieldOrPropertyWithValue("fullName", "Test User");
+
+    assertThat(result.getOAuth2Accounts())
+        .hasSize(1)
+        .allSatisfy(
+            account -> {
+              assertThat(account.getOAuth2Provider()).isEqualTo(provider);
+              assertThat(account.getOAuth2ProviderUserId()).isEqualTo("provider-user-id");
+            });
+  }
+
+  @Test
+  @DisplayName("processOAuth2User 시 계정이 존재하지만 연결되지 않은 경우 계정 연결")
+  void processOAuth2User_accountExistsButNotLinked_linksAccount() {
+    OidcUser oidcUser = mock(OidcUser.class);
+    OAuth2Provider provider = OAuth2Provider.GOOGLE;
+
+    when(oidcUser.getEmail()).thenReturn("user@email.com");
+    when(oidcUser.getSubject()).thenReturn("provider-user-id");
+
+    User existingUser = User.builder().email("user@email.com").fullName("Test User").build();
+    when(userRepository.findByEmailWithOAuthAccounts("user@email.com"))
+        .thenReturn(Optional.of(existingUser));
+    when(userRepository.save(any(User.class))).thenAnswer(i -> i.getArgument(0));
+
+    assertThat(existingUser.getOAuth2Accounts()).isEmpty();
+
+    User result = customOidcUserService.processOAuth2User(provider, oidcUser);
+    assertThat(result.getOAuth2Accounts())
+        .hasSize(1)
+        .allSatisfy(
+            account -> {
+              assertThat(account.getOAuth2Provider()).isEqualTo(provider);
+              assertThat(account.getOAuth2ProviderUserId()).isEqualTo("provider-user-id");
+            });
+  }
+
+  @Test
+  @DisplayName("processOAuth2User 시 계정이 이미 연결된 경우 변경 없음")
+  void processOAuth2User_accountAlreadyLinked_noChanges() {
+    OidcUser oidcUser = mock(OidcUser.class);
+    OAuth2Provider provider = OAuth2Provider.GOOGLE;
+    when(oidcUser.getEmail()).thenReturn("user@email.com");
+
+    User existingUser = User.builder().email("user@email.com").fullName("Test User").build();
+    existingUser
+        .getOAuth2Accounts()
+        .add(
+            UserOAuth2Account.builder()
+                .user(existingUser)
+                .oAuth2Provider(provider)
+                .oAuth2ProviderUserId("provider-user-id")
+                .build());
+
+    when(userRepository.findByEmailWithOAuthAccounts("user@email.com"))
+        .thenReturn(Optional.of(existingUser));
+    when(userRepository.save(any(User.class))).thenAnswer(i -> i.getArgument(0));
+
+    User result = customOidcUserService.processOAuth2User(provider, oidcUser);
+
+    assertThat(result)
+        .hasFieldOrPropertyWithValue("email", "user@email.com")
+        .hasFieldOrPropertyWithValue("fullName", "Test User");
+
+    assertThat(result.getOAuth2Accounts())
+        .hasSize(1)
+        .allSatisfy(
+            account -> {
+              assertThat(account.getOAuth2Provider()).isEqualTo(provider);
+              assertThat(account.getOAuth2ProviderUserId()).isEqualTo("provider-user-id");
+            });
+  }
+}


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 신규 기능
- Related Issue: Closes #12 

서버측에 OAuth client 기능을 추가했습니다. 사용자가 클라이언트에서 로그인 요청을 보내면 구글 같은 OAuth authorization server에서 authentication을 처리하고 OAuth client인 우리 서버로 redirect를 보내는 flow로 진행될 것입니다.

본 PR은 Spring의 기본 OAuth 처리 로직을 기반으로 OAuth 요청을 받아 User 테이블에 새로운 사용자를 저장하는 내용을 추가했습니다. 사용자별로 여러 OAuth provider가 연결될 수 있기 때문에 (ex. 한 사람이 구글로 로그인, 네이버로 로그인을 설정), OAuth account 정보를 담는 테이블을 새로 만들어 user 테이블로 일대다 관계로 설정했습니다.

구글 OAuth만 추가했습니다.

## PR Checklist

- [x] 코드가 정상적으로 빌드되었나요?
- [x] 적절한 테스트 코드가 추가되었나요? 추가되었다면 아래에 어떤 테스트인지 설명해 주세요.
  - [x] OIDC 계정 생성 및 OAuth Provider 추가 로직 관련 테스트 추가했습니다.
- [x] 리뷰어 설정이 완료되었나요?

## Other

### 참고사항

- 해당 기능 로컬에서 실행해보려면 .env 파일이 있어야하며, 경로는 apps/server/.env에 만드셔야합니다. 구글 client ID와 client secret은 구글 드라이브에 올린 후에 슬랙으로 링크 공유드리겠습니다.