### PR TITLE
feat: 프로필 이미지 업로드 api 구현

### DIFF
--- a/apps/server/build.gradle
+++ b/apps/server/build.gradle
@@ -46,6 +46,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-session-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:4.0.0-RC1')
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
@@ -64,6 +66,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 	testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
 	testImplementation 'org.testcontainers:testcontainers-postgresql'
+	testImplementation 'org.testcontainers:testcontainers-localstack'
+	testImplementation 'io.awspring.cloud:spring-cloud-aws-testcontainers'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	errorprone 'com.uber.nullaway:nullaway:0.12.12'
 	errorprone 'com.google.errorprone:error_prone_core:2.42.0'

--- a/apps/server/src/main/java/com/skkil/sync/config/CorsConfig.java
+++ b/apps/server/src/main/java/com/skkil/sync/config/CorsConfig.java
@@ -1,0 +1,29 @@
+package com.skkil.sync.config;
+
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsConfig {
+
+  @Value("${app.cors.allowed-origins}")
+  private String[] allowedOrigins;
+
+  @Bean
+  CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration config = new CorsConfiguration();
+    config.setAllowedOrigins(Arrays.asList(allowedOrigins));
+    config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+    config.setAllowedHeaders(List.of("*"));
+    config.setAllowCredentials(true);
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+    return source;
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/config/SecurityConfig.java
+++ b/apps/server/src/main/java/com/skkil/sync/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
         .authorizeHttpRequests(
             requests ->
                 requests
-                    .requestMatchers("/users/me", "/media/**")
+                    .requestMatchers("/users/me", "/media/**", "/profiles/me")
                     .authenticated()
                     .anyRequest()
                     .permitAll())

--- a/apps/server/src/main/java/com/skkil/sync/config/SecurityConfig.java
+++ b/apps/server/src/main/java/com/skkil/sync/config/SecurityConfig.java
@@ -23,7 +23,11 @@ public class SecurityConfig {
   SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http.authorizeHttpRequests(
             requests ->
-                requests.requestMatchers("/users/me").authenticated().anyRequest().permitAll())
+                requests
+                    .requestMatchers("/users/me", "/media/**")
+                    .authenticated()
+                    .anyRequest()
+                    .permitAll())
         .oauth2Login(
             oauth2 ->
                 oauth2

--- a/apps/server/src/main/java/com/skkil/sync/media/constant/MediaContext.java
+++ b/apps/server/src/main/java/com/skkil/sync/media/constant/MediaContext.java
@@ -1,0 +1,16 @@
+package com.skkil.sync.media.constant;
+
+public enum MediaContext {
+  PROFILE_IMAGE("profile-image");
+
+  private final String name;
+
+  MediaContext(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/media/constant/MediaStatus.java
+++ b/apps/server/src/main/java/com/skkil/sync/media/constant/MediaStatus.java
@@ -2,5 +2,6 @@ package com.skkil.sync.media.constant;
 
 public enum MediaStatus {
   PENDING,
-  UPLOADED
+  UPLOADED,
+  DELETED
 }

--- a/apps/server/src/main/java/com/skkil/sync/media/constant/MediaStatus.java
+++ b/apps/server/src/main/java/com/skkil/sync/media/constant/MediaStatus.java
@@ -1,0 +1,6 @@
+package com.skkil.sync.media.constant;
+
+public enum MediaStatus {
+  PENDING,
+  UPLOADED
+}

--- a/apps/server/src/main/java/com/skkil/sync/media/controller/MediaController.java
+++ b/apps/server/src/main/java/com/skkil/sync/media/controller/MediaController.java
@@ -1,0 +1,28 @@
+package com.skkil.sync.media.controller;
+
+import com.skkil.sync.auth.AuthenticatedUser;
+import com.skkil.sync.media.dto.request.UploadMediaRequest;
+import com.skkil.sync.media.dto.response.UploadMediaResponse;
+import com.skkil.sync.media.service.MediaService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MediaController {
+
+  private final MediaService mediaService;
+
+  public MediaController(MediaService mediaService) {
+    this.mediaService = mediaService;
+  }
+
+  @PostMapping("/media")
+  public UploadMediaResponse uploadMedia(
+      @AuthenticationPrincipal AuthenticatedUser user,
+      @RequestBody @Validated UploadMediaRequest request) {
+    return mediaService.uploadMedia(user.userId(), request);
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/media/dto/request/UploadMediaRequest.java
+++ b/apps/server/src/main/java/com/skkil/sync/media/dto/request/UploadMediaRequest.java
@@ -1,0 +1,10 @@
+package com.skkil.sync.media.dto.request;
+
+import com.skkil.sync.media.constant.MediaContext;
+import jakarta.validation.constraints.NotNull;
+
+public record UploadMediaRequest(
+    @NotNull String mediaType,
+    @NotNull MediaContext mediaContext,
+    @NotNull String fileName,
+    @NotNull Long fileSize) {}

--- a/apps/server/src/main/java/com/skkil/sync/media/dto/request/UploadMediaRequest.java
+++ b/apps/server/src/main/java/com/skkil/sync/media/dto/request/UploadMediaRequest.java
@@ -1,10 +1,12 @@
 package com.skkil.sync.media.dto.request;
 
 import com.skkil.sync.media.constant.MediaContext;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public record UploadMediaRequest(
-    @NotNull String mediaType,
+    @NotBlank String mediaType,
     @NotNull MediaContext mediaContext,
-    @NotNull String fileName,
-    @NotNull Long fileSize) {}
+    @NotBlank String fileName,
+    @NotNull @Positive Long fileSize) {}

--- a/apps/server/src/main/java/com/skkil/sync/media/dto/response/UploadMediaResponse.java
+++ b/apps/server/src/main/java/com/skkil/sync/media/dto/response/UploadMediaResponse.java
@@ -1,0 +1,7 @@
+package com.skkil.sync.media.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record UploadMediaResponse(Long mediaId, String uploadUrl, LocalDateTime expiresAt) {}

--- a/apps/server/src/main/java/com/skkil/sync/media/exception/MediaNotFoundException.java
+++ b/apps/server/src/main/java/com/skkil/sync/media/exception/MediaNotFoundException.java
@@ -1,0 +1,17 @@
+package com.skkil.sync.media.exception;
+
+import com.skkil.sync.common.exception.SyncException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+public class MediaNotFoundException extends SyncException {
+
+  public MediaNotFoundException(Long mediaId) {
+    super(String.format("Media with id %d not found.", mediaId));
+  }
+
+  @Override
+  public HttpStatusCode getStatusCode() {
+    return HttpStatus.NOT_FOUND;
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/media/model/Media.java
+++ b/apps/server/src/main/java/com/skkil/sync/media/model/Media.java
@@ -1,0 +1,74 @@
+package com.skkil.sync.media.model;
+
+import com.skkil.sync.common.domain.BaseEntity;
+import com.skkil.sync.media.constant.MediaContext;
+import com.skkil.sync.media.constant.MediaStatus;
+import com.skkil.sync.user.model.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table(name = "media_files")
+@Getter
+public class Media extends BaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "uploader_id", nullable = false)
+  private User uploader;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false)
+  private MediaStatus status;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "media_context", nullable = false)
+  private MediaContext mediaContext;
+
+  @Column(name = "media_type", nullable = false)
+  private String mediaType;
+
+  @Column(name = "bucket", nullable = false)
+  private String bucket;
+
+  @Column(name = "key", nullable = false)
+  private String key;
+
+  @Column(name = "filename", nullable = false)
+  private String fileName;
+
+  @Column(name = "size", nullable = false)
+  private Long fileSize;
+
+  protected Media() {}
+
+  @Builder
+  public Media(
+      User uploader,
+      String mediaType,
+      MediaContext mediaContext,
+      String bucket,
+      String key,
+      String fileName,
+      Long fileSize) {
+    this.uploader = uploader;
+    this.status = MediaStatus.PENDING;
+    this.mediaType = mediaType;
+    this.mediaContext = mediaContext;
+    this.bucket = bucket;
+    this.key = key;
+    this.fileName = fileName;
+    this.fileSize = fileSize;
+  }
+
+  public void setStatus(MediaStatus status) {
+    this.status = status;
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/media/repository/MediaRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/media/repository/MediaRepository.java
@@ -1,0 +1,6 @@
+package com.skkil.sync.media.repository;
+
+import com.skkil.sync.media.model.Media;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MediaRepository extends JpaRepository<Media, Long> {}

--- a/apps/server/src/main/java/com/skkil/sync/media/service/MediaService.java
+++ b/apps/server/src/main/java/com/skkil/sync/media/service/MediaService.java
@@ -2,6 +2,7 @@ package com.skkil.sync.media.service;
 
 import com.skkil.sync.media.dto.request.UploadMediaRequest;
 import com.skkil.sync.media.dto.response.UploadMediaResponse;
+import com.skkil.sync.media.exception.MediaNotFoundException;
 import com.skkil.sync.media.model.Media;
 import com.skkil.sync.media.repository.MediaRepository;
 import com.skkil.sync.user.model.User;
@@ -59,7 +60,7 @@ public class MediaService {
 
   @Transactional(readOnly = true)
   public Media getMedia(Long mediaId) {
-    return mediaRepository.findById(mediaId).orElseThrow();
+    return mediaRepository.findById(mediaId).orElseThrow(() -> new MediaNotFoundException(mediaId));
   }
 
   public URL getMediaUrl(Long mediaId) {

--- a/apps/server/src/main/java/com/skkil/sync/media/service/MediaService.java
+++ b/apps/server/src/main/java/com/skkil/sync/media/service/MediaService.java
@@ -1,0 +1,74 @@
+package com.skkil.sync.media.service;
+
+import com.skkil.sync.media.dto.request.UploadMediaRequest;
+import com.skkil.sync.media.dto.response.UploadMediaResponse;
+import com.skkil.sync.media.model.Media;
+import com.skkil.sync.media.repository.MediaRepository;
+import com.skkil.sync.user.model.User;
+import com.skkil.sync.user.service.UserService;
+import io.awspring.cloud.s3.S3Template;
+import java.io.IOException;
+import java.net.URL;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MediaService {
+
+  private final UserService userService;
+  private final MediaRepository mediaRepository;
+  private final S3Template s3Template;
+
+  public MediaService(
+      UserService userService, MediaRepository mediaRepository, S3Template s3Template) {
+    this.userService = userService;
+    this.mediaRepository = mediaRepository;
+    this.s3Template = s3Template;
+  }
+
+  @Transactional
+  public UploadMediaResponse uploadMedia(Long uploaderId, UploadMediaRequest request) {
+    User uploader = userService.getUserReference(uploaderId);
+    String bucket = request.mediaContext().toString();
+    String key = UUID.randomUUID().toString();
+
+    Media media =
+        Media.builder()
+            .uploader(uploader)
+            .mediaType(request.mediaType())
+            .mediaContext(request.mediaContext())
+            .bucket(bucket)
+            .key(key)
+            .fileName(request.fileName())
+            .fileSize(request.fileSize())
+            .build();
+    mediaRepository.save(media);
+
+    URL url = s3Template.createSignedPutURL(bucket, key, Duration.ofMinutes(10));
+
+    return UploadMediaResponse.builder()
+        .mediaId(media.getId())
+        .uploadUrl(url.toExternalForm())
+        .expiresAt(LocalDateTime.now(ZoneId.systemDefault()).plusMinutes(10))
+        .build();
+  }
+
+  @Transactional(readOnly = true)
+  public Media getMedia(Long mediaId) {
+    return mediaRepository.findById(mediaId).orElseThrow();
+  }
+
+  public URL getMediaUrl(Long mediaId) {
+    Media media = getMedia(mediaId);
+
+    try {
+      return s3Template.createResource(media.getBucket(), media.getKey()).getURL();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to get media URL", e);
+    }
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/user/controller/ProfileController.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/controller/ProfileController.java
@@ -1,0 +1,27 @@
+package com.skkil.sync.user.controller;
+
+import com.skkil.sync.auth.AuthenticatedUser;
+import com.skkil.sync.user.dto.request.UpdateProfileRequest;
+import com.skkil.sync.user.service.ProfileService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ProfileController {
+
+  private final ProfileService profileService;
+
+  public ProfileController(ProfileService profileService) {
+    this.profileService = profileService;
+  }
+
+  @PatchMapping("/profiles/me")
+  public void updateProfile(
+      @AuthenticationPrincipal AuthenticatedUser user,
+      @RequestBody @Validated UpdateProfileRequest request) {
+    profileService.updateProfile(user.userId(), request);
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/user/controller/UserController.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.skkil.sync.user.controller;
 
 import com.skkil.sync.auth.AuthenticatedUser;
 import com.skkil.sync.user.dto.response.GetAuthenticatedUserResponse;
+import com.skkil.sync.user.service.ProfileService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,10 +10,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class UserController {
 
+  private final ProfileService profileService;
+
+  public UserController(ProfileService userService) {
+    this.profileService = userService;
+  }
+
   @GetMapping("/users/me")
   public GetAuthenticatedUserResponse getAuthenticatedUser(
       @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
-    return new GetAuthenticatedUserResponse(
-        authenticatedUser.userId(), authenticatedUser.fullName(), authenticatedUser.email());
+    return profileService.getAuthenticatedUser(authenticatedUser.userId());
   }
 }

--- a/apps/server/src/main/java/com/skkil/sync/user/controller/UserController.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/controller/UserController.java
@@ -12,8 +12,8 @@ public class UserController {
 
   private final ProfileService profileService;
 
-  public UserController(ProfileService userService) {
-    this.profileService = userService;
+  public UserController(ProfileService profileService) {
+    this.profileService = profileService;
   }
 
   @GetMapping("/users/me")

--- a/apps/server/src/main/java/com/skkil/sync/user/dto/request/UpdateProfileRequest.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/dto/request/UpdateProfileRequest.java
@@ -1,0 +1,3 @@
+package com.skkil.sync.user.dto.request;
+
+public record UpdateProfileRequest(String name, Long profileImageId) {}

--- a/apps/server/src/main/java/com/skkil/sync/user/dto/response/GetAuthenticatedUserResponse.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/dto/response/GetAuthenticatedUserResponse.java
@@ -1,3 +1,7 @@
 package com.skkil.sync.user.dto.response;
 
-public record GetAuthenticatedUserResponse(Long userId, String fullName, String email) {}
+import lombok.Builder;
+
+@Builder
+public record GetAuthenticatedUserResponse(
+    Long userId, String fullName, String email, String profileImageUrl) {}

--- a/apps/server/src/main/java/com/skkil/sync/user/model/User.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/model/User.java
@@ -1,13 +1,17 @@
 package com.skkil.sync.user.model;
 
 import com.skkil.sync.common.domain.BaseEntity;
+import com.skkil.sync.media.model.Media;
 import com.skkil.sync.user.constant.Role;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -29,6 +33,11 @@ public class User extends BaseEntity {
   @Column(name = "hashed_password", nullable = true, length = 255)
   @Setter
   private String hashedPassword;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "profile_image_id", nullable = true)
+  @Setter
+  private Media profileImage;
 
   @Column(name = "full_name", nullable = false, length = 255)
   @Setter

--- a/apps/server/src/main/java/com/skkil/sync/user/model/User.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/model/User.java
@@ -35,7 +35,7 @@ public class User extends BaseEntity {
   private String hashedPassword;
 
   @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "profile_image_id", nullable = true)
+  @JoinColumn(name = "profile_image_id")
   @Setter
   private Media profileImage;
 

--- a/apps/server/src/main/java/com/skkil/sync/user/service/ProfileService.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/service/ProfileService.java
@@ -68,6 +68,10 @@ public class ProfileService {
     }
 
     if (request.profileImageId() != null) {
+      if (user.getProfileImage() != null) {
+        user.getProfileImage().setStatus(MediaStatus.DELETED);
+      }
+
       Media profileImage = mediaService.getMedia(request.profileImageId());
 
       if (!profileImage.getStatus().equals(MediaStatus.PENDING)) {

--- a/apps/server/src/main/java/com/skkil/sync/user/service/ProfileService.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/service/ProfileService.java
@@ -1,0 +1,68 @@
+package com.skkil.sync.user.service;
+
+import com.skkil.sync.media.constant.MediaStatus;
+import com.skkil.sync.media.model.Media;
+import com.skkil.sync.media.service.MediaService;
+import com.skkil.sync.user.dto.request.UpdateProfileRequest;
+import com.skkil.sync.user.dto.response.GetAuthenticatedUserResponse;
+import com.skkil.sync.user.model.User;
+import com.skkil.sync.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ProfileService {
+
+  private final UserRepository userRepository;
+  private final MediaService mediaService;
+
+  public ProfileService(UserRepository userRepository, MediaService mediaService) {
+    this.userRepository = userRepository;
+    this.mediaService = mediaService;
+  }
+
+  @Transactional(readOnly = true)
+  public GetAuthenticatedUserResponse getAuthenticatedUser(Long userId) {
+    User user = userRepository.findById(userId).orElseThrow();
+
+    String profileImageUrl = null;
+    if (user.getProfileImage() != null) {
+      profileImageUrl = mediaService.getMediaUrl(user.getProfileImage().getId()).toExternalForm();
+    }
+
+    return GetAuthenticatedUserResponse.builder()
+        .userId(user.getId())
+        .fullName(user.getFullName())
+        .email(user.getEmail())
+        .profileImageUrl(profileImageUrl)
+        .build();
+  }
+
+  @Transactional
+  public void updateProfile(Long userId, UpdateProfileRequest request) {
+    User user = userRepository.findById(userId).orElseThrow();
+
+    if (request.name() != null) {
+      user.setFullName(request.name());
+    }
+
+    if (request.profileImageId() != null) {
+      Media profileImage = mediaService.getMedia(request.profileImageId());
+
+      if (!profileImage.getStatus().equals(MediaStatus.PENDING)) {
+        throw new IllegalArgumentException(
+            "Media is not in a valid state to be used as profile image.");
+      }
+
+      if (!userId.equals(profileImage.getUploader().getId())) {
+        throw new IllegalArgumentException(
+            "User does not own the media they are trying to set as profile image.");
+      }
+
+      profileImage.setStatus(MediaStatus.UPLOADED);
+      user.setProfileImage(profileImage);
+    }
+
+    userRepository.save(user);
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/user/service/UserService.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/service/UserService.java
@@ -1,0 +1,19 @@
+package com.skkil.sync.user.service;
+
+import com.skkil.sync.user.model.User;
+import com.skkil.sync.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+  private final UserRepository userRepository;
+
+  public UserService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  public User getUserReference(Long userId) {
+    return userRepository.getReferenceById(userId);
+  }
+}

--- a/apps/server/src/main/resources/application-dev.yaml
+++ b/apps/server/src/main/resources/application-dev.yaml
@@ -1,3 +1,14 @@
+spring:
+  cloud:
+    aws:
+      endpoint: http://localhost:4566
+      region.static: us-east-1
+      credentials:
+        access-key: skkil
+        secret-key: sync
+      s3:
+        path-style-access-enabled: true
+
 logging:
   level:
     com.skkil: TRACE

--- a/apps/server/src/main/resources/application.yaml
+++ b/apps/server/src/main/resources/application.yaml
@@ -31,7 +31,19 @@ spring:
               - profile
               - email
 
+  cloud:
+    aws:
+      endpoint: http://localhost:4566
+      region.static: us-east-1
+      credentials:
+        access-key: skkil
+        secret-key: sync
+      s3:
+        config.enabled: true
+        path-style-access-enabled: true
+
 app:
+  cors.allowed-origins: http://localhost:3000
   oauth2:
     frontend-redirect-uri: http://localhost:3000
 

--- a/apps/server/src/main/resources/application.yaml
+++ b/apps/server/src/main/resources/application.yaml
@@ -33,14 +33,8 @@ spring:
 
   cloud:
     aws:
-      endpoint: http://localhost:4566
-      region.static: us-east-1
-      credentials:
-        access-key: skkil
-        secret-key: sync
       s3:
         config.enabled: true
-        path-style-access-enabled: true
 
 app:
   cors.allowed-origins: http://localhost:3000

--- a/apps/server/src/main/resources/db/changelog/changesets/00004-create-table-media-files.yaml
+++ b/apps/server/src/main/resources/db/changelog/changesets/00004-create-table-media-files.yaml
@@ -1,0 +1,73 @@
+databaseChangeLog:
+  - changeSet:
+      id: 00004-create-table-media-files
+      author: hyoungjoojin
+      preConditions:
+        - not:
+            tableExists:
+              tableName: media_files
+      changes:
+        - createTable:
+            tableName: media_files
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  defaultValueComputed: CURRENT_TIMESTAMP
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP
+                  defaultValueComputed: CURRENT_TIMESTAMP
+              - column:
+                  name: uploader_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: media_context
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: media_type
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: bucket
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: key
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: filename
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: size
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: media_files
+            baseColumnNames: uploader_id
+            referencedTableName: users
+            referencedColumnNames: id
+            constraintName: fk_media_files_uploader_id
+            onDelete: CASCADE

--- a/apps/server/src/main/resources/db/changelog/changesets/00004-create-table-media-files.yaml
+++ b/apps/server/src/main/resources/db/changelog/changesets/00004-create-table-media-files.yaml
@@ -71,3 +71,17 @@ databaseChangeLog:
             referencedColumnNames: id
             constraintName: fk_media_files_uploader_id
             onDelete: CASCADE
+
+        - addColumn:
+            tableName: users
+            columns:
+              - column:
+                  name: profile_image_id
+                  type: BIGINT
+
+        - addForeignKeyConstraint:
+            baseTableName: users
+            baseColumnNames: profile_image_id
+            referencedTableName: media_files
+            referencedColumnNames: id
+            constraintName: fk_users_profile_image_id

--- a/apps/server/src/main/resources/db/changelog/changesets/00007-create-table-media-files.yaml
+++ b/apps/server/src/main/resources/db/changelog/changesets/00007-create-table-media-files.yaml
@@ -1,6 +1,6 @@
 databaseChangeLog:
   - changeSet:
-      id: 00004-create-table-media-files
+      id: 00007-create-table-media-files
       author: hyoungjoojin
       preConditions:
         - not:
@@ -85,3 +85,4 @@ databaseChangeLog:
             referencedTableName: media_files
             referencedColumnNames: id
             constraintName: fk_users_profile_image_id
+            onDelete: SET NULL

--- a/apps/server/src/test/java/com/skkil/sync/SyncApplicationTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/SyncApplicationTests.java
@@ -4,9 +4,11 @@ import com.skkil.sync.config.TestcontainersConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
 @Import(TestcontainersConfig.class)
 @SpringBootTest
+@ActiveProfiles("dev")
 class SyncApplicationTests {
 
   @Test

--- a/infra/localstack/docker-compose.yml
+++ b/infra/localstack/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  localstack:
+    image: localstack/localstack
+    environment:
+      - "DEBUG=1"
+      - "SERVICES=s3"
+      - "AWS_ACCESS_KEY_ID=skkil"
+      - "AWS_SECRET_ACCESS_KEY=sync"
+      - "AWS_DEFAULT_REGION=us-east-1"
+      - "DISABLE_CUSTOM_CORS_S3=1"
+      - "DISABLE_CUSTOM_CORS_API_GATEWAY=1"
+      - "DISABLE_CORS_CHECKS=1"
+      - "S3_SKIP_SIGNATURE_VALIDATION=0"
+    ports:
+      - "4566:4566"
+      - "4510-4559:4510-4559"
+    volumes:
+      - "./scripts/init.sh:/etc/localstack/init/ready.d/init.sh"

--- a/infra/localstack/scripts/init.sh
+++ b/infra/localstack/scripts/init.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+export AWS_ACCESS_KEY_ID=skkil
+export AWS_SECRET_ACCESS_KEY=sync
+
+awslocal s3 mb s3://profile-image


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 신규 기능
- Related Issue: Closes #19 

사용자 데이터에 프로필 이미지를 추가했으며 프로필 사진뿐만 아니라 나중에 미디어 파일들이 많이 사용될 것이기에 media 도메인을 분리하고 user 테이블에서 media 테이블을 참조하도록 하였습니다.
S3와 같은 cloud storage를 처음부터 사용하는 것이 좋겠다고 생각했지만, dev 환경에서는 localstack을 활용해서 AWS를 대체하기로 결정했습니다. S3를 다루는 로직은 서버측 로직과 별개라고 생각되어 infra라는 폴더로 docker-compose 파일을 새로 작성했습니다.

## PR Checklist

- [x] 코드가 정상적으로 빌드되었나요?
- [x] 적절한 테스트 코드가 추가되었나요? 추가되었다면 아래에 어떤 테스트인지 설명해 주세요.
  - 추가된 로직이 많아서 사실 테스트 코드를 다 작성해야 하긴 하지만.. 제가 생각했을 때 media 관련 코드랑 로직은 나중에 상당히 많이 바뀔 것 같아 기능들이 안정화되고 나서 작성하려 했습니다.
  - 마찬가지 이유로 이미지 업로드 중에 발생할 수 있는 업로드 취소, 프로필 이미지 전환 시 기존 이미지 삭제와 같은 다양한 에러나 에지 케이스 처리는 하지 않았으며 나중에 차차 하나씩 추가하려고 계획 중입니다.
- [x] 리뷰어 설정이 완료되었나요?