### PR TITLE
feat: 학교 provider를 추가할 수 있는 form ui 추가

### DIFF
--- a/apps/web/public/locales/ko.json
+++ b/apps/web/public/locales/ko.json
@@ -31,6 +31,49 @@
         }
       }
     },
+    "create-provider": {
+      "title": "찾는 기관이 없으신가요?",
+      "description": "직접 페이지를 만들어 보세요.",
+      "links": {
+        "company": {
+          "title": "기업",
+          "description": "소규모, 중견 기업 및 대기업"
+        },
+        "school": {
+          "title": "교육 기관",
+          "description": "학교 및 대학교"
+        }
+      }
+    },
+    "create-school": {
+      "title": "만들고자 하는 학교에 대해 알려주세요",
+      "form": {
+        "name": {
+          "label": "이름",
+          "placeholder": "학교 이름을 입력하세요"
+        },
+        "description": {
+          "label": "설명",
+          "placeholder": "학교에 대한 간단한 설명을 입력하세요"
+        },
+        "school-type": {
+          "label": "학교 유형",
+          "placeholder": "학교 유형을 선택하세요",
+          "types": {
+            "UNIVERSITY": "대학교",
+            "HIGH_SCHOOL": "고등학교"
+          }
+        },
+        "submit": {
+          "label": "학교 만들기"
+        }
+      },
+      "errors": {
+        "required_name": "이름은 필수 항목입니다.",
+        "required_description": "설명은 필수 항목입니다.",
+        "required_school_type": "학교 유형은 필수 항목입니다."
+      }
+    },
     "provider": {
       "actions": {
         "follow": "팔로우",

--- a/apps/web/src/app/(app)/profile/[id]/_components/Profile.tsx
+++ b/apps/web/src/app/(app)/profile/[id]/_components/Profile.tsx
@@ -8,7 +8,7 @@ import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { useGetProfile } from '@/features/profile/api/get-profile';
-import { Experience, ExperienceCategory } from '@/types/experience';
+import { Experience, ExperienceType } from '@/types/experience';
 
 interface ProfileProps {
   userId: string;
@@ -68,8 +68,7 @@ export default function Profile({ userId }: ProfileProps) {
         <CardContent>
           {experiences
             .filter(
-              (experience) =>
-                experience.category === ExperienceCategory.EMPLOYMENT,
+              (experience) => experience.type === ExperienceType.EMPLOYMENT,
             )
             .map((employment) => (
               <div key={employment.id}>
@@ -89,8 +88,7 @@ export default function Profile({ userId }: ProfileProps) {
         <CardContent>
           {experiences
             .filter(
-              (experience) =>
-                experience.category === ExperienceCategory.EDUCATION,
+              (experience) => experience.type === ExperienceType.EDUCATION,
             )
             .map((education) => (
               <div key={education.id}>

--- a/apps/web/src/app/(app)/provider/create/company/page.tsx
+++ b/apps/web/src/app/(app)/provider/create/company/page.tsx
@@ -1,0 +1,3 @@
+export default function CreateCompany() {
+  return null;
+}

--- a/apps/web/src/app/(app)/provider/create/page.tsx
+++ b/apps/web/src/app/(app)/provider/create/page.tsx
@@ -1,0 +1,69 @@
+import {
+  BuildingOfficeIcon,
+  StudentIcon,
+} from '@phosphor-icons/react/dist/ssr';
+import { getTranslations } from 'next-intl/server';
+import Link from 'next/link';
+
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { ProviderType } from '@/types/provider';
+
+interface Provider {
+  id: string;
+  type: ProviderType;
+  icon: React.ReactNode;
+  link: string;
+}
+
+const providers: Provider[] = [
+  {
+    id: 'company',
+    type: ProviderType.COMPANY,
+    icon: <BuildingOfficeIcon />,
+    link: '/provider/create/company',
+  },
+  {
+    id: 'school',
+    type: ProviderType.SCHOOL,
+    icon: <StudentIcon />,
+    link: '/provider/create/school',
+  },
+];
+
+export default async function CreateProviderPage() {
+  const t = await getTranslations('pages.create-provider');
+
+  return (
+    <div className="flex flex-col items-center py-12 px-4">
+      <header className="text-center mb-10 max-w-2xl">
+        <h1 className="text-3xl mb-4">{t('title')}</h1>
+        <p>{t('description')}</p>
+      </header>
+
+      <div className="flex flex-col gap-4">
+        {providers.map((provider) => (
+          <Link href={provider.link} key={provider.type}>
+            <Card className="w-96 hover:outline hover:cursor-pointer">
+              <div className="flex items-center px-4">
+                <div>{provider.icon}</div>
+                <div className="grow">
+                  <CardHeader>
+                    <CardTitle>{t(`links.${provider.id}.title`)}</CardTitle>
+                    <CardDescription>
+                      {t(`links.${provider.id}.description`)}
+                    </CardDescription>
+                  </CardHeader>
+                </div>
+              </div>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/provider/create/page.tsx
+++ b/apps/web/src/app/(app)/provider/create/page.tsx
@@ -13,14 +13,14 @@ import {
 } from '@/components/ui/card';
 import { ProviderType } from '@/types/provider';
 
-interface Provider {
+interface ProviderComponentOptions {
   id: string;
   type: ProviderType;
   icon: React.ReactNode;
   link: string;
 }
 
-const providers: Provider[] = [
+const providers: ProviderComponentOptions[] = [
   {
     id: 'company',
     type: ProviderType.COMPANY,

--- a/apps/web/src/app/(app)/provider/create/school/page.tsx
+++ b/apps/web/src/app/(app)/provider/create/school/page.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { CaretLeftIcon } from '@phosphor-icons/react';
+import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { Controller, useForm } from 'react-hook-form';
+import z from 'zod';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Field, FieldGroup, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useCreateProviderMutation } from '@/features/provider/api/create-provider';
+import { ProviderType, SchoolType } from '@/types/provider';
+
+export default function CreateProvider() {
+  const t = useTranslations('pages.create-school');
+
+  const router = useRouter();
+  const { mutate: createProvider } = useCreateProviderMutation();
+
+  const CreateProviderFormSchema = z.object({
+    name: z.string().min(1, {
+      error: t('errors.required_name'),
+    }),
+    description: z.string().min(1, {
+      error: t('errors.required_description'),
+    }),
+    schoolType: z.enum(SchoolType).nonoptional({
+      error: t('errors.required_school_type'),
+    }),
+  });
+  type CreateProviderFormValues = z.infer<typeof CreateProviderFormSchema>;
+
+  const form = useForm<CreateProviderFormValues>({
+    resolver: zodResolver(CreateProviderFormSchema),
+    defaultValues: {
+      name: '',
+      description: '',
+    },
+  });
+
+  const formSubmitHandler = async (values: CreateProviderFormValues) => {
+    createProvider(
+      {
+        type: ProviderType.SCHOOL,
+        name: values.name,
+        description: values.description,
+        schoolType: values.schoolType,
+      },
+      {
+        onSuccess: (data) => {
+          router.push(`/school/${data.id}`);
+        },
+      },
+    );
+  };
+
+  return (
+    <form onSubmit={form.handleSubmit(formSubmitHandler)}>
+      <Card className="max-w-3xl mx-auto">
+        <CardHeader>
+          <Button variant="ghost" size="icon" onClick={() => router.back()}>
+            <CaretLeftIcon />
+          </Button>
+
+          <CardTitle className="text-lg">{t('title')}</CardTitle>
+        </CardHeader>
+
+        <CardContent>
+          <FieldGroup>
+            <Controller
+              name="name"
+              control={form.control}
+              render={({ field, fieldState }) => {
+                return (
+                  <Field>
+                    <FieldLabel>{t('form.name.label')}</FieldLabel>
+                    <Input
+                      {...field}
+                      aria-invalid={fieldState.invalid}
+                      placeholder={t('form.name.placeholder')}
+                    />
+                  </Field>
+                );
+              }}
+            />
+
+            <Controller
+              name="description"
+              control={form.control}
+              render={({ field, fieldState }) => {
+                return (
+                  <Field>
+                    <FieldLabel>{t('form.description.label')}</FieldLabel>
+                    <Input
+                      {...field}
+                      aria-invalid={fieldState.invalid}
+                      placeholder={t('form.description.placeholder')}
+                    />
+                  </Field>
+                );
+              }}
+            />
+
+            <Controller
+              name="schoolType"
+              control={form.control}
+              render={({ field, fieldState }) => {
+                return (
+                  <Field>
+                    <FieldLabel>{t('form.school-type.label')}</FieldLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      defaultValue={field.value}
+                      value={field.value}
+                      aria-invalid={fieldState.invalid}
+                    >
+                      <SelectTrigger>
+                        <SelectValue
+                          placeholder={t('form.school-type.placeholder')}
+                        />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Object.values(SchoolType).map((type) => (
+                          <SelectItem key={type} value={type}>
+                            {t(`form.school-type.types.${type}`)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </Field>
+                );
+              }}
+            />
+          </FieldGroup>
+        </CardContent>
+
+        <CardFooter className="flex justify-end">
+          <div>
+            <Button type="submit">{t('form.submit.label')}</Button>
+          </div>
+        </CardFooter>
+      </Card>
+    </form>
+  );
+}

--- a/apps/web/src/app/(app)/provider/create/school/page.tsx
+++ b/apps/web/src/app/(app)/provider/create/school/page.tsx
@@ -15,7 +15,12 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { Field, FieldGroup, FieldLabel } from '@/components/ui/field';
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -27,7 +32,7 @@ import {
 import { useCreateProviderMutation } from '@/features/provider/api/create-provider';
 import { ProviderType, SchoolType } from '@/types/provider';
 
-export default function CreateProvider() {
+export default function CreateSchool() {
   const t = useTranslations('pages.create-school');
 
   const router = useRouter();
@@ -74,7 +79,12 @@ export default function CreateProvider() {
     <form onSubmit={form.handleSubmit(formSubmitHandler)}>
       <Card className="max-w-3xl mx-auto">
         <CardHeader>
-          <Button variant="ghost" size="icon" onClick={() => router.back()}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={() => router.back()}
+          >
             <CaretLeftIcon />
           </Button>
 
@@ -89,7 +99,10 @@ export default function CreateProvider() {
               render={({ field, fieldState }) => {
                 return (
                   <Field>
-                    <FieldLabel>{t('form.name.label')}</FieldLabel>
+                    <div className="flex items-center justify-between">
+                      <FieldLabel>{t('form.name.label')}</FieldLabel>
+                      <FieldError errors={[fieldState.error]} />
+                    </div>
                     <Input
                       {...field}
                       aria-invalid={fieldState.invalid}
@@ -106,7 +119,10 @@ export default function CreateProvider() {
               render={({ field, fieldState }) => {
                 return (
                   <Field>
-                    <FieldLabel>{t('form.description.label')}</FieldLabel>
+                    <div className="flex items-center justify-between">
+                      <FieldLabel>{t('form.description.label')}</FieldLabel>
+                      <FieldError errors={[fieldState.error]} />
+                    </div>
                     <Input
                       {...field}
                       aria-invalid={fieldState.invalid}

--- a/apps/web/src/app/(app)/school/[id]/page.tsx
+++ b/apps/web/src/app/(app)/school/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function School() {
+  return null;
+}

--- a/apps/web/src/app/auth/login/_components/LoginForm.tsx
+++ b/apps/web/src/app/auth/login/_components/LoginForm.tsx
@@ -21,9 +21,15 @@ export default function LoginForm() {
 
   const LoginFormSchema = z.object({
     email: z
-      .email({ message: t('errors.invalid_credentials') })
-      .nonoptional({ message: t('errors.required_email') }),
-    password: z.string().nonempty({ message: t('errors.required_password') }),
+      .email({
+        error: t('errors.invalid_credentials'),
+      })
+      .nonoptional({
+        error: t('errors.required_email'),
+      }),
+    password: z.string().nonempty({
+      error: t('errors.required_password'),
+    }),
   });
 
   type LoginFormValues = z.infer<typeof LoginFormSchema>;

--- a/apps/web/src/app/auth/register/_components/RegisterForm.tsx
+++ b/apps/web/src/app/auth/register/_components/RegisterForm.tsx
@@ -24,19 +24,25 @@ export default function RegisterForm() {
   const RegisterFormSchema = z
     .object({
       email: z
-        .email({ message: t('errors.invalid_email') })
-        .nonoptional({ message: t('errors.required_email') }),
+        .email({
+          error: t('errors.invalid_email'),
+        })
+        .nonoptional({
+          error: t('errors.required_email'),
+        }),
       password: z
         .string()
-        .nonempty({ message: t('errors.required_password') })
+        .nonempty({
+          error: t('errors.required_password'),
+        })
         .min(MIN_PASSWORD_LENGTH, {
-          message: t('errors.password_min_length', {
+          error: t('errors.password_min_length', {
             length: MIN_PASSWORD_LENGTH,
           }),
         }),
-      confirmPassword: z
-        .string()
-        .nonempty({ message: t('errors.required_confirm_password') }),
+      confirmPassword: z.string().nonempty({
+        error: t('errors.required_confirm_password'),
+      }),
     })
     .superRefine((val, ctx) => {
       if (val.password !== val.confirmPassword) {

--- a/apps/web/src/components/layout/nav/NavigationBar.tsx
+++ b/apps/web/src/components/layout/nav/NavigationBar.tsx
@@ -1,4 +1,4 @@
-import { ChatCircleDotsIcon } from '@phosphor-icons/react/ssr';
+import { ChatCircleDotsIcon, PlusIcon } from '@phosphor-icons/react/ssr';
 import { headers } from 'next/headers';
 import Link from 'next/link';
 
@@ -20,6 +20,12 @@ export default async function NavigationBar() {
       </Link>
 
       <div className="flex items-center gap-2">
+        <Link href="/provider/create">
+          <Button variant="ghost" size="icon">
+            <PlusIcon />
+          </Button>
+        </Link>
+
         {session && (
           <Link href="/messages">
             <Button variant="ghost" size="icon-lg">

--- a/apps/web/src/features/provider/api/create-provider.ts
+++ b/apps/web/src/features/provider/api/create-provider.ts
@@ -1,0 +1,30 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { server } from '@/lib/server/client';
+import { ProviderType, SchoolType } from '@/types/provider';
+
+type CreateProviderRequest = {
+  name: string;
+  description: string;
+} & {
+  type: ProviderType.SCHOOL;
+  schoolType: SchoolType;
+};
+
+type CreateProviderResponse = {
+  id: number;
+};
+
+async function createProvider(request: CreateProviderRequest) {
+  return server
+    .post<CreateProviderResponse>('providers', {
+      json: request,
+    })
+    .json();
+}
+
+export function useCreateProviderMutation() {
+  return useMutation({
+    mutationFn: createProvider,
+  });
+}

--- a/apps/web/src/types/experience.ts
+++ b/apps/web/src/types/experience.ts
@@ -1,8 +1,8 @@
 import { Provider } from './provider';
 
-export enum ExperienceCategory {
-  EMPLOYMENT = 'employment',
-  EDUCATION = 'education',
+export enum ExperienceType {
+  EMPLOYMENT = 'EMPLOYMENT',
+  EDUCATION = 'EDUCATION',
 }
 
 export type Experience = {
@@ -12,10 +12,10 @@ export type Experience = {
   endDate: Date;
 } & (
   | {
-      category: ExperienceCategory.EMPLOYMENT;
+      type: ExperienceType.EMPLOYMENT;
     }
   | {
-      category: ExperienceCategory.EDUCATION;
+      type: ExperienceType.EDUCATION;
       major?: string;
     }
 );

--- a/apps/web/src/types/provider.ts
+++ b/apps/web/src/types/provider.ts
@@ -13,10 +13,10 @@ export type Provider = {
   name: string;
 } & (
   | {
-      category: ProviderType.COMPANY;
+      type: ProviderType.COMPANY;
       industry: string;
     }
   | {
-      category: ProviderType.SCHOOL;
+      type: ProviderType.SCHOOL;
     }
 );

--- a/apps/web/src/types/provider.ts
+++ b/apps/web/src/types/provider.ts
@@ -1,6 +1,11 @@
-export enum ProviderCategory {
-  COMPANY = 'company',
-  SCHOOL = 'school',
+export enum ProviderType {
+  COMPANY = 'COMPANY',
+  SCHOOL = 'SCHOOL',
+}
+
+export enum SchoolType {
+  UNIVERSITY = 'UNIVERSITY',
+  HIGH_SCHOOL = 'HIGH_SCHOOL',
 }
 
 export type Provider = {
@@ -8,10 +13,10 @@ export type Provider = {
   name: string;
 } & (
   | {
-      category: ProviderCategory.COMPANY;
+      category: ProviderType.COMPANY;
       industry: string;
     }
   | {
-      category: ProviderCategory.SCHOOL;
+      category: ProviderType.SCHOOL;
     }
 );


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 신규 기능
- Related Issue: Closes #26 

학교를 새롭게 추가할 수 있도록 form을 만들었습니다. 추가 변경 사항은 provider는 반드시 /provider/{providerID}에 위치하도록 할려고 했으나, provider type별로 들어가는 내용도 많이 다르기에 type별로 개별 페이지를 구현하는 것이 좋겠다고 판단했습니다. 예를 들어, school provider의 페이지는 /school/{providerID}에서 확인하는 것입니다.

## PR Checklist

- [x] 코드가 정상적으로 빌드되었나요?
- [x] 적절한 테스트 코드가 추가되었나요? 추가되었다면 아래에 어떤 테스트인지 설명해 주세요.
- [x] 리뷰어 설정이 완료되었나요?

## Other

### 참고사항

- 변경 사항에 대한 추가 설명이 필요하다면 적어주세요.

### Screenshots / Videos (Optional)

<img width="958" height="943" alt="스크린샷, 2026-01-31 15-15-43" src="https://github.com/user-attachments/assets/207aca53-2497-438e-8bae-71be41378434" />

<img width="957" height="943" alt="스크린샷, 2026-01-31 15-16-02" src="https://github.com/user-attachments/assets/76ae4ce0-09c1-4bc6-bafe-26f6a13d6167" />
