### PR TITLE
feat: contest 모델 추가 및 웹 클라이언트 내 form 구현

### DIFF
--- a/apps/server/src/main/java/com/skkil/sync/provider/controller/ContestController.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/controller/ContestController.java
@@ -1,0 +1,32 @@
+package com.skkil.sync.provider.controller;
+
+import com.skkil.sync.auth.AuthenticatedUser;
+import com.skkil.sync.provider.dto.request.CreateContestOccurrenceRequest;
+import com.skkil.sync.provider.service.ContestService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ContestController {
+
+  private final ContestService contestService;
+
+  public ContestController(ContestService contestService) {
+    this.contestService = contestService;
+  }
+
+  @PostMapping("/contests/{contestId}/occurrences")
+  @ResponseStatus(HttpStatus.CREATED)
+  public void createContestOccurrence(
+      @AuthenticationPrincipal AuthenticatedUser user,
+      @PathVariable Long contestId,
+      @RequestBody @Validated CreateContestOccurrenceRequest request) {
+    contestService.createContestOccurrence(contestId, request);
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/provider/controller/ProviderController.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/controller/ProviderController.java
@@ -8,6 +8,7 @@ import com.skkil.sync.provider.dto.response.CreateProviderResponse;
 import com.skkil.sync.provider.dto.response.GetProviderResponse;
 import com.skkil.sync.provider.dto.response.GetProvidersResponse;
 import com.skkil.sync.provider.service.ProviderService;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -39,8 +40,12 @@ public class ProviderController {
   }
 
   @GetMapping("/providers")
-  public GetProvidersResponse getProviders(@RequestParam(required = true) ProviderType type) {
-    return providerService.getProviders(type);
+  public GetProvidersResponse getProviders(
+      @RequestParam(required = false) String query,
+      @RequestParam(required = true) List<ProviderType> types,
+      @RequestParam(required = false) Long cursor,
+      @RequestParam(required = false, defaultValue = "50") int size) {
+    return providerService.getProviders(query, types, cursor, size);
   }
 
   @GetMapping("/providers/{id}")

--- a/apps/server/src/main/java/com/skkil/sync/provider/dto/request/CreateContestOccurrenceRequest.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/dto/request/CreateContestOccurrenceRequest.java
@@ -1,0 +1,5 @@
+package com.skkil.sync.provider.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateContestOccurrenceRequest(@NotBlank String title, String description) {}

--- a/apps/server/src/main/java/com/skkil/sync/provider/dto/request/CreateContestRequest.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/dto/request/CreateContestRequest.java
@@ -1,0 +1,9 @@
+package com.skkil.sync.provider.dto.request;
+
+import com.skkil.sync.provider.constant.ProviderType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateContestRequest(
+    @NotNull ProviderType type, @NotBlank String name, String description, Long hostProviderId)
+    implements CreateProviderRequest {}

--- a/apps/server/src/main/java/com/skkil/sync/provider/dto/request/CreateProviderRequest.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/dto/request/CreateProviderRequest.java
@@ -11,9 +11,11 @@ import com.skkil.sync.provider.constant.ProviderType;
     visible = true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = CreateSchoolRequest.class, name = ProviderType.Constants.SCHOOL),
-  @JsonSubTypes.Type(value = CreateLabRequest.class, name = ProviderType.Constants.LAB)
+  @JsonSubTypes.Type(value = CreateLabRequest.class, name = ProviderType.Constants.LAB),
+  @JsonSubTypes.Type(value = CreateContestRequest.class, name = ProviderType.Constants.CONTEST)
 })
-public sealed interface CreateProviderRequest permits CreateSchoolRequest, CreateLabRequest {
+public sealed interface CreateProviderRequest
+    permits CreateSchoolRequest, CreateLabRequest, CreateContestRequest {
 
   ProviderType type();
 

--- a/apps/server/src/main/java/com/skkil/sync/provider/dto/request/UpdateContestRequest.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/dto/request/UpdateContestRequest.java
@@ -1,0 +1,6 @@
+package com.skkil.sync.provider.dto.request;
+
+import com.skkil.sync.provider.constant.ProviderType;
+
+public record UpdateContestRequest(ProviderType type, String name, String description)
+    implements UpdateProviderRequest {}

--- a/apps/server/src/main/java/com/skkil/sync/provider/dto/request/UpdateProviderRequest.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/dto/request/UpdateProviderRequest.java
@@ -11,9 +11,11 @@ import com.skkil.sync.provider.constant.ProviderType;
     visible = true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = UpdateSchoolRequest.class, name = ProviderType.Constants.SCHOOL),
-  @JsonSubTypes.Type(value = UpdateLabRequest.class, name = ProviderType.Constants.LAB)
+  @JsonSubTypes.Type(value = UpdateLabRequest.class, name = ProviderType.Constants.LAB),
+  @JsonSubTypes.Type(value = UpdateContestRequest.class, name = ProviderType.Constants.CONTEST),
 })
-public sealed interface UpdateProviderRequest permits UpdateSchoolRequest, UpdateLabRequest {
+public sealed interface UpdateProviderRequest
+    permits UpdateSchoolRequest, UpdateLabRequest, UpdateContestRequest {
 
   ProviderType type();
 

--- a/apps/server/src/main/java/com/skkil/sync/provider/dto/response/GetContestResponse.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/dto/response/GetContestResponse.java
@@ -1,0 +1,21 @@
+package com.skkil.sync.provider.dto.response;
+
+import com.skkil.sync.provider.constant.ProviderType;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record GetContestResponse(
+    Long id,
+    ProviderType type,
+    String name,
+    String description,
+    Long verifiedBy,
+    Provider hostProvider,
+    String contactInfo,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt)
+    implements GetProviderResponse {
+
+  public static record Provider(Long id, ProviderType type, String name) {}
+}

--- a/apps/server/src/main/java/com/skkil/sync/provider/dto/response/GetProviderResponse.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/dto/response/GetProviderResponse.java
@@ -12,9 +12,11 @@ import java.time.LocalDateTime;
     visible = true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = GetSchoolResponse.class, name = ProviderType.Constants.SCHOOL),
-  @JsonSubTypes.Type(value = GetLabResponse.class, name = ProviderType.Constants.LAB)
+  @JsonSubTypes.Type(value = GetLabResponse.class, name = ProviderType.Constants.LAB),
+  @JsonSubTypes.Type(value = GetContestResponse.class, name = ProviderType.Constants.CONTEST)
 })
-public sealed interface GetProviderResponse permits GetSchoolResponse, GetLabResponse {
+public sealed interface GetProviderResponse
+    permits GetSchoolResponse, GetLabResponse, GetContestResponse {
 
   Long id();
 

--- a/apps/server/src/main/java/com/skkil/sync/provider/dto/response/GetProvidersResponse.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/dto/response/GetProvidersResponse.java
@@ -1,8 +1,11 @@
 package com.skkil.sync.provider.dto.response;
 
-import java.util.List;
+import com.skkil.sync.provider.constant.ProviderType;
+import lombok.Builder;
+import org.springframework.data.domain.Page;
 
-public record GetProvidersResponse(List<Provider> providers) {
+public record GetProvidersResponse(Page<Provider> providers) {
 
-  public static record Provider(String id, String name) {}
+  @Builder
+  public static record Provider(ProviderType type, String id, String name) {}
 }

--- a/apps/server/src/main/java/com/skkil/sync/provider/model/Contest.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/model/Contest.java
@@ -1,0 +1,29 @@
+package com.skkil.sync.provider.model;
+
+import com.skkil.sync.provider.constant.ProviderType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "contests")
+@Getter
+public class Contest extends Provider {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "host_provider_id", nullable = false)
+  @Setter
+  private Provider hostProvider;
+
+  protected Contest() {}
+
+  @Builder
+  public Contest(String name, String description, String contactInfo, String oneLineReview) {
+    super(ProviderType.CONTEST, name, description, contactInfo, oneLineReview);
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/provider/model/ContestOccurrence.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/model/ContestOccurrence.java
@@ -1,0 +1,36 @@
+package com.skkil.sync.provider.model;
+
+import com.skkil.sync.common.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table(name = "contest_occurrences")
+@Getter
+public class ContestOccurrence extends BaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "contest_id", nullable = false)
+  private Contest contest;
+
+  @Column(name = "occurrence_name", nullable = false)
+  private String title;
+
+  @Column(name = "description")
+  private String description;
+
+  protected ContestOccurrence() {}
+
+  @Builder
+  public ContestOccurrence(Contest contest, String title, String description) {
+    this.contest = contest;
+    this.title = title;
+    this.description = description;
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/provider/repository/ContestOccurrenceRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/repository/ContestOccurrenceRepository.java
@@ -1,0 +1,6 @@
+package com.skkil.sync.provider.repository;
+
+import com.skkil.sync.provider.model.ContestOccurrence;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContestOccurrenceRepository extends JpaRepository<ContestOccurrence, Long> {}

--- a/apps/server/src/main/java/com/skkil/sync/provider/repository/ContestRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/repository/ContestRepository.java
@@ -1,0 +1,6 @@
+package com.skkil.sync.provider.repository;
+
+import com.skkil.sync.provider.model.Contest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContestRepository extends JpaRepository<Contest, Long> {}

--- a/apps/server/src/main/java/com/skkil/sync/provider/repository/ProviderRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/repository/ProviderRepository.java
@@ -13,7 +13,7 @@ public interface ProviderRepository extends JpaRepository<Provider, Long> {
   @Query(
       """
       SELECT p FROM Provider p
-      WHERE p.name LIKE :query%
+      WHERE (:query IS NOT NULL AND p.name LIKE :query%)
         AND p.type IN :types
         AND (p.id > :cursor OR :cursor IS NULL)
         AND p.verifiedBy IS NOT NULL

--- a/apps/server/src/main/java/com/skkil/sync/provider/repository/ProviderRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/repository/ProviderRepository.java
@@ -10,8 +10,17 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface ProviderRepository extends JpaRepository<Provider, Long> {
 
-  @Query("SELECT p FROM Provider p WHERE p.type = :type AND p.verifiedBy IS NOT NULL")
-  public List<Provider> findByTypeAndVerified(ProviderType type);
+  @Query(
+      """
+      SELECT p FROM Provider p
+      WHERE p.name LIKE :query%
+        AND p.type IN :types
+        AND (p.id > :cursor OR :cursor IS NULL)
+        AND p.verifiedBy IS NOT NULL
+      ORDER BY p.id
+      """)
+  public Page<Provider> searchByTypeAndVerified(
+      String query, List<ProviderType> types, Long cursor, Pageable pageable);
 
   @Query("SELECT p FROM Provider p WHERE p.verifiedBy IS NULL")
   public Page<Provider> findUnverifiedProviders(Pageable pageable);

--- a/apps/server/src/main/java/com/skkil/sync/provider/security/ProviderPermissionEvaluator.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/security/ProviderPermissionEvaluator.java
@@ -36,6 +36,7 @@ public class ProviderPermissionEvaluator implements CustomPermissionEvaluator {
 
     return switch (permission) {
       case READ -> canRead(user, provider);
+      case UPDATE -> canUpdate(user, provider);
 
       default -> {
         log.debug("Unsupported permission operation: {}", permission);
@@ -66,6 +67,31 @@ public class ProviderPermissionEvaluator implements CustomPermissionEvaluator {
     if (user.userId().equals(provider.getCreatedBy().getId())) {
       log.debug(
           "User {} is the creator, granting read access to unverified provider {}",
+          user.userId(),
+          provider.getId());
+      return true;
+    }
+
+    return false;
+  }
+
+  private boolean canUpdate(AuthenticatedUser user, Provider provider) {
+    if (user == null) {
+      log.debug("Unauthenticated user trying to update provider {}", provider.getId());
+      return false;
+    }
+
+    if (user.isAdmin()) {
+      log.debug(
+          "User {} is admin, granting update access to provider {}",
+          user.userId(),
+          provider.getId());
+      return true;
+    }
+
+    if (user.userId().equals(provider.getCreatedBy().getId())) {
+      log.debug(
+          "User {} is the creator, granting update access to provider {}",
           user.userId(),
           provider.getId());
       return true;

--- a/apps/server/src/main/java/com/skkil/sync/provider/service/ContestService.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/service/ContestService.java
@@ -16,6 +16,7 @@ import com.skkil.sync.provider.repository.ContestRepository;
 import com.skkil.sync.provider.repository.ProviderRepository;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,10 +60,12 @@ public class ContestService implements ProviderStrategy {
     Contest contest = (Contest) provider;
 
     var hostProvider =
-        new GetContestResponse.Provider(
-            contest.getHostProvider().getId(),
-            contest.getHostProvider().getType(),
-            contest.getHostProvider().getName());
+        contest.getHostProvider() == null
+            ? null
+            : new GetContestResponse.Provider(
+                contest.getHostProvider().getId(),
+                contest.getHostProvider().getType(),
+                contest.getHostProvider().getName());
 
     return GetContestResponse.builder()
         .id(provider.getId())
@@ -92,6 +95,7 @@ public class ContestService implements ProviderStrategy {
   }
 
   @Transactional
+  @PreAuthorize("hasPermission(#contestId, 'PROVIDER', 'EDIT')")
   public void createContestOccurrence(Long contestId, CreateContestOccurrenceRequest request) {
     Contest contest = contestRepository.getReferenceById(contestId);
 

--- a/apps/server/src/main/java/com/skkil/sync/provider/service/ContestService.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/service/ContestService.java
@@ -1,0 +1,106 @@
+package com.skkil.sync.provider.service;
+
+import com.skkil.sync.provider.constant.ProviderType;
+import com.skkil.sync.provider.dto.request.CreateContestOccurrenceRequest;
+import com.skkil.sync.provider.dto.request.CreateContestRequest;
+import com.skkil.sync.provider.dto.request.CreateProviderRequest;
+import com.skkil.sync.provider.dto.request.UpdateContestRequest;
+import com.skkil.sync.provider.dto.request.UpdateProviderRequest;
+import com.skkil.sync.provider.dto.response.GetContestResponse;
+import com.skkil.sync.provider.dto.response.GetProviderResponse;
+import com.skkil.sync.provider.model.Contest;
+import com.skkil.sync.provider.model.ContestOccurrence;
+import com.skkil.sync.provider.model.Provider;
+import com.skkil.sync.provider.repository.ContestOccurrenceRepository;
+import com.skkil.sync.provider.repository.ContestRepository;
+import com.skkil.sync.provider.repository.ProviderRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ContestService implements ProviderStrategy {
+
+  private final ProviderRepository providerRepository;
+  private final ContestRepository contestRepository;
+  private final ContestOccurrenceRepository contestOccurrenceRepository;
+
+  public ContestService(
+      ProviderRepository providerRepository,
+      ContestRepository contestRepository,
+      ContestOccurrenceRepository contestOccurrenceRepository) {
+    this.providerRepository = providerRepository;
+    this.contestRepository = contestRepository;
+    this.contestOccurrenceRepository = contestOccurrenceRepository;
+  }
+
+  @Override
+  public ProviderType getProviderType() {
+    return ProviderType.CONTEST;
+  }
+
+  @Override
+  public Provider createProvider(CreateProviderRequest request) {
+    CreateContestRequest contestRequest = (CreateContestRequest) request;
+
+    Contest contest =
+        Contest.builder().name(request.name()).description(request.description()).build();
+
+    if (contestRequest.hostProviderId() != null) {
+      contest.setHostProvider(providerRepository.getReferenceById(contestRequest.hostProviderId()));
+    }
+
+    return contest;
+  }
+
+  @Override
+  public GetProviderResponse toGetProviderResponse(Provider provider) {
+    Contest contest = (Contest) provider;
+
+    var hostProvider =
+        new GetContestResponse.Provider(
+            contest.getHostProvider().getId(),
+            contest.getHostProvider().getType(),
+            contest.getHostProvider().getName());
+
+    return GetContestResponse.builder()
+        .id(provider.getId())
+        .type(provider.getType())
+        .name(provider.getName())
+        .description(provider.getDescription())
+        .verifiedBy(provider.getVerifiedBy() != null ? provider.getVerifiedBy().getId() : null)
+        .hostProvider(hostProvider)
+        .contactInfo(provider.getContactInfo())
+        .createdAt(LocalDateTime.ofInstant(provider.getCreatedAt(), ZoneId.systemDefault()))
+        .updatedAt(LocalDateTime.ofInstant(provider.getUpdatedAt(), ZoneId.systemDefault()))
+        .build();
+  }
+
+  @Override
+  @Transactional
+  public void updateProvider(Provider provider, UpdateProviderRequest request) {
+    UpdateContestRequest contestRequest = (UpdateContestRequest) request;
+
+    if (contestRequest.name() != null) {
+      provider.setName(contestRequest.name());
+    }
+
+    if (contestRequest.description() != null) {
+      provider.setDescription(contestRequest.description());
+    }
+  }
+
+  @Transactional
+  public void createContestOccurrence(Long contestId, CreateContestOccurrenceRequest request) {
+    Contest contest = contestRepository.getReferenceById(contestId);
+
+    ContestOccurrence occurrence =
+        ContestOccurrence.builder()
+            .contest(contest)
+            .title(request.title())
+            .description(request.description())
+            .build();
+    contestOccurrenceRepository.save(occurrence);
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/provider/service/ProviderService.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/service/ProviderService.java
@@ -49,16 +49,19 @@ public class ProviderService {
   }
 
   @Transactional(readOnly = true)
-  public GetProvidersResponse getProviders(ProviderType type) {
-    List<Provider> providers = providerRepository.findByTypeAndVerified(type);
+  public GetProvidersResponse getProviders(
+      String query, List<ProviderType> types, Long cursor, int size) {
+    PageRequest pageRequest = PageRequest.of(0, size);
 
+    var providers = providerRepository.searchByTypeAndVerified(query, types, cursor, pageRequest);
     return new GetProvidersResponse(
-        providers.stream()
-            .map(
-                provider ->
-                    new GetProvidersResponse.Provider(
-                        provider.getId().toString(), provider.getName()))
-            .toList());
+        providers.map(
+            provider ->
+                GetProvidersResponse.Provider.builder()
+                    .type(provider.getType())
+                    .id(provider.getId().toString())
+                    .name(provider.getName())
+                    .build()));
   }
 
   @Transactional(readOnly = true)

--- a/apps/server/src/main/resources/db/changelog/changesets/00011-create-table-contests.yaml
+++ b/apps/server/src/main/resources/db/changelog/changesets/00011-create-table-contests.yaml
@@ -18,11 +18,10 @@ databaseChangeLog:
               - column:
                   name: host_provider_id
                   type: BIGINT
-                  constraints:
-                    nullable: false
         - addForeignKeyConstraint:
             baseTableName: contests
             baseColumnNames: host_provider_id
             referencedTableName: providers
             referencedColumnNames: id
             constraintName: fk_contests_providers
+            onDelete: CASCADE

--- a/apps/server/src/main/resources/db/changelog/changesets/00011-create-table-contests.yaml
+++ b/apps/server/src/main/resources/db/changelog/changesets/00011-create-table-contests.yaml
@@ -1,0 +1,28 @@
+databaseChangeLog:
+  - changeSet:
+      id: 00011-create-table-contests
+      author: hyoungjoojin
+      preConditions:
+        - not:
+            tableExists:
+              tableName: contests
+      changes:
+        - createTable:
+            tableName: contests
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: host_provider_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: contests
+            baseColumnNames: host_provider_id
+            referencedTableName: providers
+            referencedColumnNames: id
+            constraintName: fk_contests_providers

--- a/apps/server/src/main/resources/db/changelog/changesets/00012-create-table-contest-occurrences.yaml
+++ b/apps/server/src/main/resources/db/changelog/changesets/00012-create-table-contest-occurrences.yaml
@@ -1,0 +1,46 @@
+databaseChangeLog:
+  - changeSet:
+      id: 00012-create-table-contest-occurrences
+      author: hyoungjoojin
+      preConditions:
+        - not:
+            tableExists:
+              tableName: contest_occurrences
+      changes:
+        - createTable:
+            tableName: contest_occurrences
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  defaultValueComputed: CURRENT_TIMESTAMP
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP
+                  defaultValueComputed: CURRENT_TIMESTAMP
+              - column:
+                  name: contest_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: occurrence_name
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: TEXT
+        - addForeignKeyConstraint:
+            baseTableName: contest_occurrences
+            baseColumnNames: contest_id
+            referencedTableName: contests
+            referencedColumnNames: id
+            constraintName: fk_contest_occurrences_contest_id
+            onDelete: CASCADE

--- a/apps/web/public/locales/ko.json
+++ b/apps/web/public/locales/ko.json
@@ -34,6 +34,9 @@
     "create-provider": {
       "title": "찾는 기관이 없으신가요?",
       "description": "직접 페이지를 만들어 보세요.",
+      "or-other": {
+        "label": "또는"
+      },
       "links": {
         "company": {
           "title": "기업",
@@ -42,6 +45,10 @@
         "school": {
           "title": "교육 기관",
           "description": "학교 및 대학교"
+        },
+        "contest": {
+          "title": "대회",
+          "description": "대회 및 공모전 페이지"
         }
       }
     },
@@ -74,6 +81,31 @@
         "required_school_type": "학교 유형은 필수 항목입니다."
       }
     },
+    "create-contest": {
+      "title": "만들고자 하는 대회에 대해 알려주세요",
+      "form": {
+        "name": {
+          "label": "이름",
+          "placeholder": "대회 이름을 입력하세요"
+        },
+        "description": {
+          "label": "설명",
+          "placeholder": "대회에 대한 간단한 설명을 입력하세요"
+        },
+        "host": {
+          "label": "주최 기관",
+          "placeholder": "대회를 주최하는 기관을 입력하세요"
+        },
+        "submit": {
+          "label": "대회 만들기"
+        }
+      },
+      "errors": {
+        "required_name": "이름은 필수 항목입니다.",
+        "required_description": "설명은 필수 항목입니다.",
+        "required_school_type": "학교 유형은 필수 항목입니다."
+      }
+    },
     "provider": {
       "actions": {
         "follow": "팔로우",
@@ -95,7 +127,8 @@
       "sections": {
         "about": "소개",
         "people": "관련 인물",
-        "reviews": "리뷰"
+        "reviews": "리뷰",
+        "occurrences": "회차"
       }
     },
     "login": {
@@ -215,18 +248,6 @@
         "EDUCATION": "이전 및 현재 학교 정보를 추가하세요"
       },
       "form": {
-        "provider": {
-          "label": {
-            "EMPLOYMENT": "회사를 선택하세요",
-            "EDUCATION": "학교를 선택하세요"
-          },
-          "placeholder": {
-            "EMPLOYMENT": "회사 이름을 입력하세요",
-            "EDUCATION": "학교 이름을 입력하세요"
-          },
-          "not-found": "기관을 찾을 수 없으십니까?",
-          "create-link": "여기를 클릭하여 새 기관을 만드세요"
-        },
         "major": {
           "label": "전공",
           "placeholder": "전공을 입력하세요"
@@ -239,7 +260,6 @@
             "label": "취소"
           }
         },
-
         "errors": {
           "required-provider": "기관은 필수 항목입니다.",
           "required-major": "전공은 필수 항목입니다."
@@ -279,6 +299,13 @@
         "settings": "설정",
         "sign-out": "로그아웃"
       }
+    },
+    "select-providers": {
+      "label": "기관 선택",
+      "placeholder": "기관을 검색하세요",
+      "provider-not-found": "기관을 찾을 수 없으십니까?",
+      "create-link": "여기를 클릭하여 새 기관을 만드세요",
+      "enter-query": "검색어를 입력하세요"
     }
   },
   "errors": {

--- a/apps/web/public/locales/ko.json
+++ b/apps/web/public/locales/ko.json
@@ -102,8 +102,7 @@
       },
       "errors": {
         "required_name": "이름은 필수 항목입니다.",
-        "required_description": "설명은 필수 항목입니다.",
-        "required_school_type": "학교 유형은 필수 항목입니다."
+        "required_description": "설명은 필수 항목입니다."
       }
     },
     "provider": {

--- a/apps/web/src/app/(app)/contest/[id]/page.tsx
+++ b/apps/web/src/app/(app)/contest/[id]/page.tsx
@@ -1,0 +1,77 @@
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
+import { getTranslations } from 'next-intl/server';
+
+import { Card } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { GetProviderQueryOptions } from '@/features/provider/api/get-provider';
+import ProviderAbout from '@/features/provider/components/ProviderAbout';
+import ProviderOverview from '@/features/provider/components/ProviderOverview';
+import ProviderRelatedPeople from '@/features/provider/components/ProviderPeople';
+import ProviderReviews from '@/features/provider/components/ProviderReviews';
+import { getQueryClient } from '@/lib/query';
+import { ProviderType } from '@/types/provider';
+
+interface ContestProps {
+  params: Promise<{
+    id: string;
+  }>;
+}
+
+export default async function Contest({ params }: ContestProps) {
+  const { id } = await params;
+  const t = await getTranslations('pages.provider');
+
+  const queryClient = getQueryClient();
+  await queryClient.prefetchQuery(GetProviderQueryOptions(id));
+
+  const tabs = [
+    {
+      id: 'about',
+      title: t('sections.about'),
+      content: <ProviderAbout />,
+    },
+    {
+      id: 'occurrences',
+      title: t('sections.occurrences'),
+      content: <div></div>,
+    },
+    {
+      id: 'people',
+      title: t('sections.people'),
+      content: <ProviderRelatedPeople />,
+    },
+    {
+      id: 'reviews',
+      title: t('sections.reviews'),
+      content: <ProviderReviews />,
+    },
+  ];
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <div className="max-w-5xl mx-auto p-4 flex flex-col gap-5">
+        <ProviderOverview id={id} type={ProviderType.CONTEST} />
+
+        <div className="grow">
+          <Tabs defaultValue={tabs[0]?.id} className="w-full">
+            <TabsList>
+              {tabs.map((tab) => (
+                <TabsTrigger key={tab.id} value={tab.id}>
+                  {tab.title}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+
+            <Card className="min-h-96 overflow-auto">
+              {tabs.map((tab) => (
+                <TabsContent key={tab.id} value={tab.id}>
+                  {tab.content}
+                </TabsContent>
+              ))}
+            </Card>
+          </Tabs>
+        </div>
+      </div>
+    </HydrationBoundary>
+  );
+}

--- a/apps/web/src/app/(app)/profile/[id]/_components/AddExperienceButton.tsx
+++ b/apps/web/src/app/(app)/profile/[id]/_components/AddExperienceButton.tsx
@@ -1,20 +1,11 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { PencilIcon } from '@phosphor-icons/react';
 import { useTranslations } from 'next-intl';
-import { useRouter } from 'next/navigation';
 import { useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import z from 'zod';
 
 import { Button } from '@/components/ui/button';
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
 import {
   Dialog,
   DialogContent,
@@ -26,15 +17,11 @@ import {
 } from '@/components/ui/dialog';
 import { Field, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
 import { useCreateExperienceMutation } from '@/features/experience/api/create-experience';
-import { useGetProvidersQuery } from '@/features/provider/api/get-providers';
-import { getProviderForExperience } from '@/features/provider/util';
+import SelectProviders from '@/features/provider/components/SelectProviders';
+import { getProviderForExperience as getProviderTypeForExperience } from '@/features/provider/util';
 import { ExperienceType } from '@/types/experience';
+import { ProviderType } from '@/types/provider';
 
 interface AddExperienceButtonProps {
   type: ExperienceType;
@@ -159,63 +146,15 @@ function ProviderField({
   invalid?: boolean;
   onChange: (value: { id: string; name: string }) => void;
 }) {
-  const t = useTranslations('pages.add-experience.form');
-  const router = useRouter();
-
-  const { data: providers } = useGetProvidersQuery({
-    type: getProviderForExperience(type),
-  });
-
   return (
     <Field data-invalid={invalid}>
-      <Popover>
-        <PopoverTrigger asChild>
-          {value.name ? (
-            <Button variant="outline">{value.name}</Button>
-          ) : (
-            <Button variant="outline">{t(`provider.label.${type}`)}</Button>
-          )}
-        </PopoverTrigger>
-
-        <PopoverContent
-          aria-modal={true}
-          className="z-50 pointer-events-auto p-0 w-[var(--radix-popover-trigger-width)]"
-        >
-          <Command>
-            <CommandInput placeholder={t(`provider.placeholder.${type}`)} />
-            <CommandList>
-              <CommandEmpty>
-                <div>{t('provider.not-found')}</div>
-
-                <div
-                  className="text-xs hover:underline cursor-pointer"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    router.push('/provider/create');
-                  }}
-                >
-                  {t('provider.create-link')}
-                </div>
-              </CommandEmpty>
-              <CommandGroup>
-                {providers?.map((provider) => (
-                  <CommandItem
-                    key={provider.id}
-                    onSelect={() => {
-                      onChange({
-                        id: provider.id,
-                        name: provider.name,
-                      });
-                    }}
-                  >
-                    {provider.name}
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </PopoverContent>
-      </Popover>
+      <SelectProviders
+        types={[getProviderTypeForExperience(type) as ProviderType]}
+        value={value.id}
+        onChange={(values) => {
+          onChange(values);
+        }}
+      />
     </Field>
   );
 }

--- a/apps/web/src/app/(app)/profile/[id]/_components/AddExperienceButton.tsx
+++ b/apps/web/src/app/(app)/profile/[id]/_components/AddExperienceButton.tsx
@@ -19,7 +19,7 @@ import { Field, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { useCreateExperienceMutation } from '@/features/experience/api/create-experience';
 import SelectProviders from '@/features/provider/components/SelectProviders';
-import { getProviderForExperience as getProviderTypeForExperience } from '@/features/provider/util';
+import { getProviderTypeForExperienceType } from '@/features/provider/util';
 import { ExperienceType } from '@/types/experience';
 import { ProviderType } from '@/types/provider';
 
@@ -133,7 +133,6 @@ function AddExperienceForm({
 }
 
 function ProviderField({
-  value,
   type,
   invalid,
   onChange,
@@ -149,8 +148,7 @@ function ProviderField({
   return (
     <Field data-invalid={invalid}>
       <SelectProviders
-        types={[getProviderTypeForExperience(type) as ProviderType]}
-        value={value.id}
+        types={[getProviderTypeForExperienceType(type) as ProviderType]}
         onChange={(values) => {
           onChange(values);
         }}

--- a/apps/web/src/app/(app)/provider/create/contest/page.tsx
+++ b/apps/web/src/app/(app)/provider/create/contest/page.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { CaretLeftIcon } from '@phosphor-icons/react';
+import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { Controller, useForm } from 'react-hook-form';
+import z from 'zod';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import { useCreateProviderMutation } from '@/features/provider/api/create-provider';
+import SelectProviders from '@/features/provider/components/SelectProviders';
+import { ProviderType } from '@/types/provider';
+
+export default function CreateContest() {
+  const t = useTranslations('pages.create-contest');
+
+  const router = useRouter();
+  const { mutate: createProvider } = useCreateProviderMutation();
+
+  const CreateProviderFormSchema = z.object({
+    name: z.string().min(1, {
+      error: t('errors.required_name'),
+    }),
+    description: z.string().min(1, {
+      error: t('errors.required_description'),
+    }),
+    hostProviderId: z.string(),
+  });
+  type CreateProviderFormValues = z.infer<typeof CreateProviderFormSchema>;
+
+  const form = useForm<CreateProviderFormValues>({
+    resolver: zodResolver(CreateProviderFormSchema),
+    defaultValues: {
+      name: '',
+      description: '',
+      hostProviderId: '',
+    },
+  });
+
+  const formSubmitHandler = async (values: CreateProviderFormValues) => {
+    createProvider(
+      {
+        type: ProviderType.CONTEST,
+        name: values.name,
+        description: values.description,
+        hostProviderId: values.hostProviderId || undefined,
+      },
+      {
+        onSuccess: (data) => {
+          router.push(`/contest/${data.id}`);
+        },
+      },
+    );
+  };
+
+  return (
+    <form onSubmit={form.handleSubmit(formSubmitHandler)}>
+      <Card className="max-w-3xl mx-auto">
+        <CardHeader>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={() => router.back()}
+          >
+            <CaretLeftIcon />
+          </Button>
+
+          <CardTitle className="text-lg">{t('title')}</CardTitle>
+        </CardHeader>
+
+        <CardContent>
+          <FieldGroup>
+            <Controller
+              name="name"
+              control={form.control}
+              render={({ field, fieldState }) => {
+                return (
+                  <Field>
+                    <div className="flex items-center justify-between">
+                      <FieldLabel>{t('form.name.label')}</FieldLabel>
+                      <FieldError errors={[fieldState.error]} />
+                    </div>
+                    <Input
+                      {...field}
+                      aria-invalid={fieldState.invalid}
+                      placeholder={t('form.name.placeholder')}
+                    />
+                  </Field>
+                );
+              }}
+            />
+
+            <Controller
+              name="description"
+              control={form.control}
+              render={({ field, fieldState }) => {
+                return (
+                  <Field>
+                    <div className="flex items-center justify-between">
+                      <FieldLabel>{t('form.description.label')}</FieldLabel>
+                      <FieldError errors={[fieldState.error]} />
+                    </div>
+                    <Input
+                      {...field}
+                      aria-invalid={fieldState.invalid}
+                      placeholder={t('form.description.placeholder')}
+                    />
+                  </Field>
+                );
+              }}
+            />
+
+            <Controller
+              name="hostProviderId"
+              control={form.control}
+              render={({ field, fieldState }) => {
+                return (
+                  <Field>
+                    <div className="flex items-center justify-between">
+                      <FieldLabel>{t('form.host.label')}</FieldLabel>
+                      <FieldError errors={[fieldState.error]} />
+                    </div>
+                    <SelectProviders
+                      value={field.value}
+                      placeholder={t('form.host.placeholder')}
+                      onChange={({ id }) => {
+                        field.onChange(id);
+                      }}
+                      types={[ProviderType.SCHOOL, ProviderType.COMPANY]}
+                    />
+                  </Field>
+                );
+              }}
+            />
+          </FieldGroup>
+        </CardContent>
+
+        <CardFooter className="flex justify-end">
+          <div>
+            <Button type="submit">{t('form.submit.label')}</Button>
+          </div>
+        </CardFooter>
+      </Card>
+    </form>
+  );
+}

--- a/apps/web/src/app/(app)/provider/create/contest/page.tsx
+++ b/apps/web/src/app/(app)/provider/create/contest/page.tsx
@@ -137,7 +137,6 @@ export default function CreateContest() {
                       <FieldError errors={[fieldState.error]} />
                     </div>
                     <SelectProviders
-                      value={field.value}
                       placeholder={t('form.host.placeholder')}
                       onChange={({ id }) => {
                         field.onChange(id);

--- a/apps/web/src/app/(app)/provider/create/page.tsx
+++ b/apps/web/src/app/(app)/provider/create/page.tsx
@@ -1,6 +1,7 @@
 import {
   BuildingOfficeIcon,
   StudentIcon,
+  TrophyIcon,
 } from '@phosphor-icons/react/dist/ssr';
 import { getTranslations } from 'next-intl/server';
 import Link from 'next/link';
@@ -35,6 +36,15 @@ const providers: ProviderComponentOptions[] = [
   },
 ];
 
+const otherProviders: ProviderComponentOptions[] = [
+  {
+    id: 'contest',
+    type: ProviderType.CONTEST,
+    icon: <TrophyIcon />,
+    link: '/provider/create/contest',
+  },
+];
+
 export default async function CreateProviderPage() {
   const t = await getTranslations('pages.create-provider');
 
@@ -63,6 +73,30 @@ export default async function CreateProviderPage() {
             </Card>
           </Link>
         ))}
+      </div>
+
+      <p className="my-6">{t('or-other.label')}</p>
+
+      <div>
+        <div className="flex flex-col gap-4">
+          {otherProviders.map((provider) => (
+            <Link href={provider.link} key={provider.type}>
+              <Card className="w-96 hover:outline hover:cursor-pointer">
+                <div className="flex items-center px-4">
+                  <div>{provider.icon}</div>
+                  <div className="grow">
+                    <CardHeader>
+                      <CardTitle>{t(`links.${provider.id}.title`)}</CardTitle>
+                      <CardDescription>
+                        {t(`links.${provider.id}.description`)}
+                      </CardDescription>
+                    </CardHeader>
+                  </div>
+                </div>
+              </Card>
+            </Link>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/features/provider/api/create-provider.ts
+++ b/apps/web/src/features/provider/api/create-provider.ts
@@ -6,11 +6,16 @@ import { ProviderType, SchoolType } from '@/types/provider';
 type CreateProviderRequest = {
   name: string;
   description: string;
-} & {
-  type: ProviderType.SCHOOL;
-  schoolType: SchoolType;
-};
-
+} & (
+  | {
+      type: ProviderType.SCHOOL;
+      schoolType: SchoolType;
+    }
+  | {
+      type: ProviderType.CONTEST;
+      hostProviderId?: string;
+    }
+);
 type CreateProviderResponse = {
   id: number;
 };

--- a/apps/web/src/features/provider/api/get-providers.ts
+++ b/apps/web/src/features/provider/api/get-providers.ts
@@ -2,24 +2,32 @@ import { useQuery } from '@tanstack/react-query';
 
 import { server } from '@/lib/server';
 import { ProviderType } from '@/types/provider';
+import { PagedResponse } from '@/types/server';
 import { url } from '@/util/server';
 
 interface GetProvidersParams {
-  type: ProviderType;
+  query?: string;
+  types: ProviderType[];
+  cursor: string | null;
+  size: number;
 }
 
 interface GetProvidersResponse {
-  providers: {
+  providers: PagedResponse<{
+    type: ProviderType;
     id: string;
     name: string;
-  }[];
+  }>;
 }
 
-async function getProviders({ type }: GetProvidersParams) {
+async function getProviders(params: GetProvidersParams) {
   return await server
     .get<GetProvidersResponse>(
       url('providers', {
-        type,
+        query: params.query || undefined,
+        types: params.types.join(','),
+        cursor: params.cursor || undefined,
+        size: params.size,
       }),
     )
     .json()

--- a/apps/web/src/features/provider/components/SelectProviders.tsx
+++ b/apps/web/src/features/provider/components/SelectProviders.tsx
@@ -1,0 +1,128 @@
+import { useDebounce } from '@uidotdev/usehooks';
+import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Spinner } from '@/components/ui/spinner';
+import { ProviderType } from '@/types/provider';
+
+import { useGetProvidersQuery } from '../api/get-providers';
+
+interface SelectProvidersProps {
+  placeholder?: string;
+  value: string;
+  onChange: (value: { type: ProviderType; id: string; name: string }) => void;
+  types: ProviderType[];
+}
+
+export default function SelectProviders({
+  placeholder,
+  onChange,
+  types,
+}: SelectProvidersProps) {
+  const t = useTranslations('components.select-providers');
+  const router = useRouter();
+
+  const [query, setQuery] = useState('');
+  const debouncedQuery = useDebounce(query, 300);
+
+  const [selectedProvider, setSelectedProvider] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+
+  const { data: providers, isPending: isGetProvidersPending } =
+    useGetProvidersQuery({
+      query: debouncedQuery,
+      types,
+      cursor: '',
+      size: 10,
+    });
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline">
+          {selectedProvider ? selectedProvider.name : placeholder || t('label')}
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        aria-modal={true}
+        className="z-50 pointer-events-auto p-0 w-[var(--radix-popover-trigger-width)]"
+      >
+        <Command shouldFilter={false}>
+          <CommandInput
+            value={query}
+            onValueChange={(content) => setQuery(content)}
+          />
+          <CommandList>
+            {isGetProvidersPending ? (
+              <div className="flex items-center justify-center py-4">
+                <Spinner />
+              </div>
+            ) : (
+              <>
+                <CommandEmpty>
+                  {query.length > 0 ? (
+                    <>
+                      <div>{t('provider-not-found')}</div>
+
+                      <div
+                        className="text-xs hover:underline cursor-pointer"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          router.push('/provider/create');
+                        }}
+                      >
+                        {t('create-link')}
+                      </div>
+                    </>
+                  ) : (
+                    <div>{t('enter-query')}</div>
+                  )}
+                </CommandEmpty>
+                <CommandGroup>
+                  {providers &&
+                    providers.content.map((provider) => (
+                      <CommandItem
+                        key={provider.id}
+                        value={provider.id}
+                        onSelect={() => {
+                          onChange({
+                            type: provider.type,
+                            id: provider.id,
+                            name: provider.name,
+                          });
+                          setSelectedProvider({
+                            id: provider.id,
+                            name: provider.name,
+                          });
+                        }}
+                      >
+                        {provider.name}
+                      </CommandItem>
+                    ))}
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/features/provider/components/SelectProviders.tsx
+++ b/apps/web/src/features/provider/components/SelectProviders.tsx
@@ -24,7 +24,6 @@ import { useGetProvidersQuery } from '../api/get-providers';
 
 interface SelectProvidersProps {
   placeholder?: string;
-  value: string;
   onChange: (value: { type: ProviderType; id: string; name: string }) => void;
   types: ProviderType[];
 }

--- a/apps/web/src/features/provider/util/index.ts
+++ b/apps/web/src/features/provider/util/index.ts
@@ -1,7 +1,7 @@
 import { ExperienceType } from '@/types/experience';
 import { ProviderType } from '@/types/provider';
 
-export function getProviderForExperience(type: ExperienceType) {
+export function getProviderTypeForExperienceType(type: ExperienceType) {
   switch (type) {
     case ExperienceType.EDUCATION:
       return ProviderType.SCHOOL;

--- a/apps/web/src/types/provider.ts
+++ b/apps/web/src/types/provider.ts
@@ -1,6 +1,7 @@
 export enum ProviderType {
   COMPANY = 'COMPANY',
   SCHOOL = 'SCHOOL',
+  CONTEST = 'CONTEST',
 }
 
 export enum SchoolType {
@@ -18,5 +19,8 @@ export type Provider = {
     }
   | {
       type: ProviderType.SCHOOL;
+    }
+  | {
+      type: ProviderType.CONTEST;
     }
 );


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 신규 기능
- Related Issue: Closes #66

대회 및 공모전에 대응되는 contest provider에 관한 기본 내용들을 추가했습니다. 주최 기관을 연결할 수 있도록 하였으며, 반복되는 회차 (ex. 1회, 2회, 등)를 나타낼 수 있는 contest occurrence 데이터 모델도 추가했습니다 (UI쪽에서는 작업하지 않았습니다).
웹 클라인트의 폼 자체는 기업/학교와 크게 다르지 않으며, 다만 provider를 검색해야하는 컴포넌트가 많이 사용될 것 같아 공통 컴포넌트로 빼주었습니다.

## PR Checklist

- [x] 코드가 정상적으로 빌드되었나요?
- [ ] 적절한 테스트 코드가 추가되었나요? 추가되었다면 아래에 어떤 테스트인지 설명해 주세요.
- [x] 리뷰어 설정이 완료되었나요?
