### PR TITLE
fix: email/password 로그인 시 세션 동기화 문제 해결 및 oauth 사용자 registration 로직 수정

### DIFF
--- a/apps/server/src/main/java/com/skkil/sync/config/OAuthSecurityConfig.java
+++ b/apps/server/src/main/java/com/skkil/sync/config/OAuthSecurityConfig.java
@@ -1,0 +1,37 @@
+package com.skkil.sync.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class OAuthSecurityConfig {
+
+  @Value("${app.oauth2.frontend-redirect-uri}")
+  private String frontendRedirectUri;
+
+  private final OidcUserService oidcUserService;
+
+  public OAuthSecurityConfig(OidcUserService oidcUserService) {
+    this.oidcUserService = oidcUserService;
+  }
+
+  @Bean
+  @Order(1)
+  SecurityFilterChain oAuthSecurityFilterChain(HttpSecurity http) throws Exception {
+    return http.securityMatcher("/oauth2/**", "/login/oauth2/**")
+        .oauth2Login(
+            oauth2 ->
+                oauth2
+                    .userInfoEndpoint(userInfo -> userInfo.oidcUserService(oidcUserService))
+                    .successHandler(
+                        (req, res, auth) -> {
+                          res.sendRedirect(frontendRedirectUri);
+                        }))
+        .build();
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/config/SecurityConfig.java
+++ b/apps/server/src/main/java/com/skkil/sync/config/SecurityConfig.java
@@ -1,10 +1,9 @@
 package com.skkil.sync.config;
 
 import com.skkil.sync.common.security.GlobalPermissionEvaluator;
-import com.skkil.sync.user.service.oauth2.CustomOidcUserService;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
@@ -29,18 +28,11 @@ import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 @EnableMethodSecurity(prePostEnabled = true, securedEnabled = true)
 public class SecurityConfig {
 
-  @Value("${app.oauth2.frontend-redirect-uri}")
-  private String frontendRedirectUri;
-
-  private final CustomOidcUserService customOidcUserService;
-
-  public SecurityConfig(CustomOidcUserService customOidcUserService) {
-    this.customOidcUserService = customOidcUserService;
-  }
-
   @Bean
+  @Order(2)
   SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-    http.csrf(
+    http.securityMatcher("/**")
+        .csrf(
             csrf ->
                 csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
                     .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler()))
@@ -61,14 +53,6 @@ public class SecurityConfig {
                     .permitAll()
                     .anyRequest()
                     .authenticated())
-        .oauth2Login(
-            oauth2 ->
-                oauth2
-                    .userInfoEndpoint(userInfo -> userInfo.oidcUserService(customOidcUserService))
-                    .successHandler(
-                        (req, res, auth) -> {
-                          res.sendRedirect(frontendRedirectUri);
-                        }))
         .exceptionHandling(
             exception ->
                 exception.authenticationEntryPoint(

--- a/apps/server/src/main/java/com/skkil/sync/notification/listener/UserRegisteredEventListener.java
+++ b/apps/server/src/main/java/com/skkil/sync/notification/listener/UserRegisteredEventListener.java
@@ -3,12 +3,14 @@ package com.skkil.sync.notification.listener;
 import com.skkil.sync.notification.constant.NotificationType;
 import com.skkil.sync.notification.event.NotificationEvent;
 import com.skkil.sync.user.event.UserRegisteredEvent;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
+@Slf4j
 public class UserRegisteredEventListener {
 
   private final ApplicationEventPublisher eventPublisher;
@@ -18,8 +20,9 @@ public class UserRegisteredEventListener {
   }
 
   @Async
-  @EventListener
+  @TransactionalEventListener
   public void handleUserRegisteredEvent(UserRegisteredEvent event) {
+    log.debug("User registered event received for user ID: {}", event.getUserId());
     eventPublisher.publishEvent(new NotificationEvent(event.getUserId(), NotificationType.WELCOME));
   }
 }

--- a/apps/server/src/main/java/com/skkil/sync/notification/service/NotificationProcessorService.java
+++ b/apps/server/src/main/java/com/skkil/sync/notification/service/NotificationProcessorService.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -46,12 +47,7 @@ public class NotificationProcessorService {
       return;
     }
 
-    Notification notification =
-        Notification.builder()
-            .user(new User(event.getRecipientId()))
-            .type(event.getNotificationType())
-            .build();
-    notification = notificationRepository.save(notification);
+    Notification notification = createNotification(event);
 
     for (ChannelType channelType : preferences.getEnabledChannelTypes()) {
       NotificationChannel channel = channels.get(channelType);
@@ -62,5 +58,15 @@ public class NotificationProcessorService {
       log.debug("Sending notification {} via channel {}", notification.getId(), channelType);
       channel.send(event.getRecipientId(), "Notification " + notification.getId());
     }
+  }
+
+  @Transactional
+  Notification createNotification(NotificationEvent event) {
+    Notification notification =
+        Notification.builder()
+            .user(new User(event.getRecipientId()))
+            .type(event.getNotificationType())
+            .build();
+    return notificationRepository.save(notification);
   }
 }

--- a/apps/server/src/main/java/com/skkil/sync/user/model/User.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/model/User.java
@@ -60,7 +60,7 @@ public class User extends BaseEntity {
 
   @OneToMany(
       mappedBy = "user",
-      cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
+      cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
       orphanRemoval = true)
   private List<UserOAuth2Account> oAuth2Accounts = new ArrayList<>();
 

--- a/apps/server/src/main/java/com/skkil/sync/user/service/AuthService.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/service/AuthService.java
@@ -58,7 +58,7 @@ public class AuthService {
   }
 
   @Transactional
-  public void registerUser(RegisterRequest request) {
+  public User registerUser(RegisterRequest request) {
     if (userRepository.findByEmail(request.email()).isPresent()) {
       throw new UserAlreadyExistsException(request.email());
     }
@@ -79,5 +79,7 @@ public class AuthService {
     log.info("Registered new user with id {}", user.getId());
 
     eventPublisher.publishEvent(new UserRegisteredEvent(user.getId()));
+
+    return user;
   }
 }

--- a/apps/server/src/main/java/com/skkil/sync/user/service/oauth2/CustomOidcUserService.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/service/oauth2/CustomOidcUserService.java
@@ -2,9 +2,12 @@ package com.skkil.sync.user.service.oauth2;
 
 import com.skkil.sync.auth.AuthenticatedUser;
 import com.skkil.sync.user.constant.OAuth2Provider;
+import com.skkil.sync.user.dto.request.RegisterRequest;
 import com.skkil.sync.user.model.User;
 import com.skkil.sync.user.model.UserOAuth2Account;
 import com.skkil.sync.user.repository.UserRepository;
+import com.skkil.sync.user.service.AuthService;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
@@ -17,9 +20,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class CustomOidcUserService extends OidcUserService {
 
+  private final AuthService authService;
   private final UserRepository userRepository;
 
-  public CustomOidcUserService(UserRepository userRepository) {
+  public CustomOidcUserService(AuthService authService, UserRepository userRepository) {
+    this.authService = authService;
     this.userRepository = userRepository;
   }
 
@@ -45,16 +50,18 @@ public class CustomOidcUserService extends OidcUserService {
   @Transactional
   public User processOAuth2User(OAuth2Provider provider, OidcUser oidcUser) {
     String email = oidcUser.getEmail();
-    String fullName = oidcUser.getFullName() == null ? "" : oidcUser.getFullName();
 
-    User user =
-        userRepository
-            .findByEmailWithOAuthAccounts(email)
-            .orElseGet(
-                () -> {
-                  log.debug("User not found with email: {}. Creating new user.", email);
-                  return User.builder().email(email).fullName(fullName).build();
-                });
+    Optional<User> optionalUser = userRepository.findByEmailWithOAuthAccounts(email);
+
+    User user;
+
+    if (optionalUser.isPresent()) {
+      user = optionalUser.get();
+    } else {
+      log.debug("User not found with email: {}. Creating new user.", email);
+      user = authService.registerUser(new RegisterRequest(email, null));
+      user.setFullName(oidcUser.getFullName() == null ? "" : oidcUser.getFullName());
+    }
 
     if (user.getOAuth2Accounts().stream()
         .noneMatch(account -> provider.equals(account.getOAuth2Provider()))) {
@@ -66,8 +73,9 @@ public class CustomOidcUserService extends OidcUserService {
                   .oAuth2Provider(provider)
                   .oAuth2ProviderUserId(oidcUser.getSubject())
                   .build());
+      user = userRepository.save(user);
     }
 
-    return userRepository.save(user);
+    return user;
   }
 }

--- a/apps/server/src/test/java/com/skkil/sync/user/controller/AuthControllerTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/user/controller/AuthControllerTests.java
@@ -1,7 +1,6 @@
 package com.skkil.sync.user.controller;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -69,8 +68,6 @@ class AuthControllerTests {
   @Test
   void register() throws Exception {
     RegisterRequest request = new RegisterRequest("newuser@example.com", "password123");
-
-    doNothing().when(authService).registerUser(any(RegisterRequest.class));
 
     mockMvc
         .perform(

--- a/apps/server/src/test/java/com/skkil/sync/user/service/oauth2/CustomOidcUserServiceTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/user/service/oauth2/CustomOidcUserServiceTests.java
@@ -7,9 +7,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.skkil.sync.user.constant.OAuth2Provider;
+import com.skkil.sync.user.dto.request.RegisterRequest;
 import com.skkil.sync.user.model.User;
 import com.skkil.sync.user.model.UserOAuth2Account;
 import com.skkil.sync.user.repository.UserRepository;
+import com.skkil.sync.user.service.AuthService;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,6 +28,7 @@ public class CustomOidcUserServiceTests {
 
   @InjectMocks private CustomOidcUserService customOidcUserService;
 
+  @Mock private AuthService authService;
   @Mock private UserRepository userRepository;
 
   @Test
@@ -53,6 +56,14 @@ public class CustomOidcUserServiceTests {
 
     when(userRepository.findByEmailWithOAuthAccounts("user@email.com"))
         .thenReturn(Optional.empty());
+
+    when(authService.registerUser(any(RegisterRequest.class)))
+        .thenAnswer(
+            i -> {
+              RegisterRequest request = i.getArgument(0);
+              return User.builder().email(request.email()).fullName("").build();
+            });
+
     when(userRepository.save(any(User.class))).thenAnswer(i -> i.getArgument(0));
 
     User result = customOidcUserService.processOAuth2User(provider, oidcUser);
@@ -115,7 +126,6 @@ public class CustomOidcUserServiceTests {
 
     when(userRepository.findByEmailWithOAuthAccounts("user@email.com"))
         .thenReturn(Optional.of(existingUser));
-    when(userRepository.save(any(User.class))).thenAnswer(i -> i.getArgument(0));
 
     User result = customOidcUserService.processOAuth2User(provider, oidcUser);
 

--- a/apps/web/src/app/auth/login/_components/LoginForm.tsx
+++ b/apps/web/src/app/auth/login/_components/LoginForm.tsx
@@ -17,12 +17,15 @@ import {
 } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { useLoginMutation } from '@/features/auth/api/login';
+import { useSession } from '@/lib/auth/client';
 
 export default function LoginForm() {
   const t = useTranslations('pages.login.form');
 
   const router = useRouter();
   const { mutate: login } = useLoginMutation();
+
+  const { refetch: refetchSession } = useSession();
 
   const LoginFormSchema = z.object({
     email: z
@@ -55,6 +58,7 @@ export default function LoginForm() {
       },
       {
         onSuccess: () => {
+          refetchSession();
           router.push('/');
         },
         onError: () => {


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 버그 수정
- Related Issue: Closes #70 

email/password로 로그인했을 때 세션이 동기화되지 않았던 문제 해결했습니다. better-auth의 세션 초기화만 해주면 됐어서 한 줄로 고칠 수 있었습니다.

이슈와는 관계 없지만 OAuth 사용자의 가입 과정이 email/password로 가입한 사용자와 달라서 admin 관련 로직이 다르게 작동하고 있었습니다. 해당 부분 똑같이 작동하도록 리팩토링 진행했습니다.

## PR Checklist

- [x] 코드가 정상적으로 빌드되었나요?
- [x] 적절한 테스트 코드가 추가되었나요? 추가되었다면 아래에 어떤 테스트인지 설명해 주세요.
- [x] 리뷰어 설정이 완료되었나요?