### PR TITLE
feat: connections table 추가

### DIFF
--- a/apps/server/src/main/java/com/skkil/sync/user/controller/UserRelationshipController.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/controller/UserRelationshipController.java
@@ -1,10 +1,12 @@
 package com.skkil.sync.user.controller;
 
 import com.skkil.sync.auth.AuthenticatedUser;
+import com.skkil.sync.user.dto.response.GetConnectionsResponse;
 import com.skkil.sync.user.service.UserRelationshipService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -24,6 +26,12 @@ public class UserRelationshipController {
   public void followUser(
       @AuthenticationPrincipal AuthenticatedUser follower, @PathVariable Long followeeId) {
     userRelationshipService.followUser(follower.userId(), followeeId);
+  }
+
+  @GetMapping("/users/connections")
+  @ResponseStatus(HttpStatus.OK)
+  public GetConnectionsResponse getConnections(@AuthenticationPrincipal AuthenticatedUser user) {
+    return userRelationshipService.getConnections(user.userId());
   }
 
   @DeleteMapping("/users/unfollow/{followeeId}")

--- a/apps/server/src/main/java/com/skkil/sync/user/dto/response/GetConnectionsResponse.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/dto/response/GetConnectionsResponse.java
@@ -1,0 +1,8 @@
+package com.skkil.sync.user.dto.response;
+
+import java.util.List;
+
+public record GetConnectionsResponse(List<Connection> connections) {
+
+  public static record Connection(Long userId, String name) {}
+}

--- a/apps/server/src/main/java/com/skkil/sync/user/dto/response/GetConnectionsResponse.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/dto/response/GetConnectionsResponse.java
@@ -4,5 +4,5 @@ import java.util.List;
 
 public record GetConnectionsResponse(List<Connection> connections) {
 
-  public static record Connection(Long userId, String name) {}
+  public static record Connection(String userId, String name) {}
 }

--- a/apps/server/src/main/java/com/skkil/sync/user/repository/UserFollowRelationshipRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/repository/UserFollowRelationshipRepository.java
@@ -1,12 +1,18 @@
 package com.skkil.sync.user.repository;
 
+import com.skkil.sync.user.model.User;
 import com.skkil.sync.user.model.UserFollowRelationship;
+import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface UserFollowRelationshipRepository
     extends JpaRepository<UserFollowRelationship, Long> {
+
+  @EntityGraph(attributePaths = {"followee"})
+  List<UserFollowRelationship> findByFollower(User follower);
 
   @Query(
       """

--- a/apps/server/src/main/java/com/skkil/sync/user/service/UserRelationshipService.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/service/UserRelationshipService.java
@@ -1,5 +1,6 @@
 package com.skkil.sync.user.service;
 
+import com.skkil.sync.user.dto.response.GetConnectionsResponse;
 import com.skkil.sync.user.exception.UserCannotFollowSelfException;
 import com.skkil.sync.user.model.User;
 import com.skkil.sync.user.model.UserFollowRelationship;
@@ -43,6 +44,20 @@ public class UserRelationshipService {
     var relationship =
         UserFollowRelationship.builder().follower(follower).followee(followee).build();
     userFollowRelationshipRepository.save(relationship);
+  }
+
+  @Transactional(readOnly = true)
+  public GetConnectionsResponse getConnections(Long userId) {
+    log.debug("Retrieving connections for user {}", userId);
+    var followers = userFollowRelationshipRepository.findByFollower(new User(userId));
+
+    return new GetConnectionsResponse(
+        followers.stream()
+            .map(
+                follower ->
+                    new GetConnectionsResponse.Connection(
+                        follower.getFollowee().getId(), follower.getFollowee().getFullName()))
+            .toList());
   }
 
   @Transactional(readOnly = true)

--- a/apps/server/src/main/java/com/skkil/sync/user/service/UserRelationshipService.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/service/UserRelationshipService.java
@@ -49,14 +49,15 @@ public class UserRelationshipService {
   @Transactional(readOnly = true)
   public GetConnectionsResponse getConnections(Long userId) {
     log.debug("Retrieving connections for user {}", userId);
-    var followers = userFollowRelationshipRepository.findByFollower(new User(userId));
+    var connections = userFollowRelationshipRepository.findByFollower(new User(userId));
 
     return new GetConnectionsResponse(
-        followers.stream()
+        connections.stream()
             .map(
                 follower ->
                     new GetConnectionsResponse.Connection(
-                        follower.getFollowee().getId(), follower.getFollowee().getFullName()))
+                        follower.getFollowee().getId().toString(),
+                        follower.getFollowee().getFullName()))
             .toList());
   }
 

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -16,6 +16,7 @@ const eslintConfig = defineConfig([
   {
     rules: {
       'no-console': 'warn',
+      'react-hooks/incompatible-library': 'off',
     },
   },
 ]);

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -16,7 +16,6 @@ const eslintConfig = defineConfig([
   {
     rules: {
       'no-console': 'warn',
-      'react-hooks/incompatible-library': 'off',
     },
   },
 ]);

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,9 +1,7 @@
 import type { NextConfig } from 'next';
 import createNextIntlPlugin from 'next-intl/plugin';
 
-const nextConfig: NextConfig = {
-  reactCompiler: false,
-};
+const nextConfig: NextConfig = {};
 
 const withNextIntl = createNextIntlPlugin('./src/lib/i18n.ts');
 export default withNextIntl(nextConfig);

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from 'next';
 import createNextIntlPlugin from 'next-intl/plugin';
 
 const nextConfig: NextConfig = {
-  reactCompiler: true,
+  reactCompiler: false,
 };
 
 const withNextIntl = createNextIntlPlugin('./src/lib/i18n.ts');

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "@stomp/stompjs": "^7.2.1",
     "@t3-oss/env-nextjs": "^0.13.10",
     "@tanstack/react-query": "^5.90.19",
+    "@tanstack/react-table": "^8.21.3",
     "@uidotdev/usehooks": "^2.4.1",
     "better-auth": "^1.4.17",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.19
         version: 5.90.19(react@19.2.3)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@uidotdev/usehooks':
         specifier: ^2.4.1
         version: 2.4.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1807,6 +1810,17 @@ packages:
     resolution: {integrity: sha512-qTZRZ4QyTzQc+M0IzrbKHxSeISUmRB3RPGmao5bT+sI6ayxSRhn0FXEnT5Hg3as8SBFcRosrXXRFB+yAcxVxJQ==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@trivago/prettier-plugin-sort-imports@6.0.2':
     resolution: {integrity: sha512-3DgfkukFyC/sE/VuYjaUUWoFfuVjPK55vOFDsxD56XXynFMCZDYFogH2l/hDfOsQAm1myoU/1xByJ3tWqtulXA==}
@@ -6010,6 +6024,14 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.90.19
       react: 19.2.3
+
+  '@tanstack/react-table@8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@trivago/prettier-plugin-sort-imports@6.0.2(prettier@3.8.0)':
     dependencies:

--- a/apps/web/public/locales/ko.json
+++ b/apps/web/public/locales/ko.json
@@ -337,7 +337,8 @@
       "connections": {
         "title": "네트워크",
         "table": {
-          "name": "이름"
+          "name": "이름",
+          "empty": "네트워크에 연결된 사람이 없습니다."
         }
       }
     },

--- a/apps/web/public/locales/ko.json
+++ b/apps/web/public/locales/ko.json
@@ -333,6 +333,14 @@
         "title": "학력"
       }
     },
+    "network": {
+      "connections": {
+        "title": "네트워크",
+        "table": {
+          "name": "이름"
+        }
+      }
+    },
     "add-experience": {
       "title": {
         "EMPLOYMENT": "경력 추가",

--- a/apps/web/src/app/(app)/network/_components/ConnectionsTable.tsx
+++ b/apps/web/src/app/(app)/network/_components/ConnectionsTable.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { DataTable } from '@/components/ui/data-table';
+import { useGetConnectionsQuery } from '@/features/user/api/get-connections';
+import { columns } from '@/features/user/components/connection/ConnectionTableColumns';
+
+export default function ConnectionsTable() {
+  const t = useTranslations('pages.network.connections.table');
+
+  const { data: connections } = useGetConnectionsQuery();
+
+  return <DataTable columns={columns} data={connections || []} t={t} />;
+}

--- a/apps/web/src/app/(app)/network/page.tsx
+++ b/apps/web/src/app/(app)/network/page.tsx
@@ -1,0 +1,32 @@
+import { getTranslations } from 'next-intl/server';
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+import { auth } from '@/lib/auth';
+
+import ConnectionsTable from './_components/ConnectionsTable';
+
+export default async function Network() {
+  const t = await getTranslations('pages.network');
+
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    redirect('/auth/login');
+  }
+
+  if (session && !session.user.isOnboarded) {
+    redirect('/onboarding');
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto">
+      <div className="flex flex-col gap-4">
+        <h2 className="text-xl">{t('connections.title')}</h2>
+        <ConnectionsTable />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/nav/NavigationBar.tsx
+++ b/apps/web/src/components/layout/nav/NavigationBar.tsx
@@ -1,4 +1,8 @@
-import { ChatCircleDotsIcon, PlusIcon } from '@phosphor-icons/react/ssr';
+import {
+  ChatCircleDotsIcon,
+  PlusIcon,
+  UsersIcon,
+} from '@phosphor-icons/react/ssr';
 import { headers } from 'next/headers';
 import Link from 'next/link';
 
@@ -28,6 +32,12 @@ export default async function NavigationBar() {
             <Link href="/provider/create">
               <Button variant="ghost" size="icon">
                 <PlusIcon />
+              </Button>
+            </Link>
+
+            <Link href="/network">
+              <Button variant="ghost" size="icon">
+                <UsersIcon />
               </Button>
             </Link>
 

--- a/apps/web/src/components/ui/data-table.tsx
+++ b/apps/web/src/components/ui/data-table.tsx
@@ -7,6 +7,7 @@ import {
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table';
+import * as React from 'react';
 
 import {
   Table,
@@ -29,6 +30,7 @@ export function DataTable<TData, TValue>({
   data,
   t,
 }: DataTableProps<TData, TValue>) {
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data,
     columns,
@@ -76,7 +78,7 @@ export function DataTable<TData, TValue>({
           ) : (
             <TableRow>
               <TableCell colSpan={columns.length} className="h-24 text-center">
-                No results.
+                {t('empty')}
               </TableCell>
             </TableRow>
           )}

--- a/apps/web/src/components/ui/data-table.tsx
+++ b/apps/web/src/components/ui/data-table.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import {
+  Column,
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Translations } from '@/types/i18n';
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+  t: Translations;
+}
+
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+  t,
+}: DataTableProps<TData, TValue>) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    meta: {
+      t,
+    },
+  });
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                return (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </TableHead>
+                );
+              })}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows?.length ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow
+                key={row.id}
+                data-state={row.getIsSelected() && 'selected'}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columns.length} className="h-24 text-center">
+                No results.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+interface DataTableColumnHeaderProps<
+  TData,
+  TValue,
+> extends React.HTMLAttributes<HTMLDivElement> {
+  column: Column<TData, TValue>;
+  title: string;
+}
+
+export function DataTableColumnHeader<TData, TValue>({
+  title,
+}: DataTableColumnHeaderProps<TData, TValue>) {
+  return <>{title}</>;
+}

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Table({ className, ...props }: React.ComponentProps<'table'>) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn('w-full caption-bottom text-sm', className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn('[&_tr]:border-b', className)}
+      {...props}
+    />
+  );
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn('[&_tr:last-child]:border-0', className)}
+      {...props}
+    />
+  );
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        'bg-muted/50 border-t font-medium [&>tr]:last:border-b-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        'text-foreground h-12 px-3 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        'p-3 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<'caption'>) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn('text-muted-foreground mt-4 text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+};

--- a/apps/web/src/features/user/api/get-connections.ts
+++ b/apps/web/src/features/user/api/get-connections.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { server } from '@/lib/server';
+
+interface GetConnectionsResponse {
+  connections: {
+    userId: string;
+    name: string;
+  }[];
+}
+
+async function getConnections() {
+  return server
+    .get<GetConnectionsResponse>('users/connections')
+    .json()
+    .then((data) =>
+      data.connections.map((connection) => ({
+        id: connection.userId,
+        name: connection.name,
+      })),
+    );
+}
+
+export function useGetConnectionsQuery() {
+  return useQuery({
+    queryKey: ['connections'],
+    queryFn: getConnections,
+  });
+}

--- a/apps/web/src/features/user/components/connection/ConnectionTableColumns.tsx
+++ b/apps/web/src/features/user/components/connection/ConnectionTableColumns.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { ColumnDef } from '@tanstack/react-table';
+import Link from 'next/link';
+
+import { DataTableColumnHeader } from '@/components/ui/data-table';
+
+export type Connection = {
+  id: string;
+  name: string;
+};
+
+export const columns: ColumnDef<Connection>[] = [
+  {
+    accessorKey: 'name',
+    header: ({ column, table }) => (
+      <DataTableColumnHeader
+        title={table.options.meta?.t('name') || ''}
+        column={column}
+      />
+    ),
+    cell: ({ row }) => {
+      const { id, name } = row.original;
+      return <Link href={`/profile/${id}`}>{name}</Link>;
+    },
+  },
+];

--- a/apps/web/src/types/i18n.ts
+++ b/apps/web/src/types/i18n.ts
@@ -1,0 +1,3 @@
+import type { useTranslations } from 'next-intl';
+
+export type Translations = ReturnType<typeof useTranslations>;

--- a/apps/web/typings/tanstack-table.d.ts
+++ b/apps/web/typings/tanstack-table.d.ts
@@ -1,0 +1,7 @@
+import type { Translations } from '@/types/i18n';
+
+declare module '@tanstack/react-table' {
+  interface TableMeta {
+    t: Translations;
+  }
+}


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 신규 기능
- Related Issue: #88 

네트워킹 페이지를 추가했습니다. 사용자들이 자신이 팔로우하고 있는 사람들의 리스트를 받아볼 수 있도록 했습니다. shadcn의 table과 tanstack react-table을 사용했으며 diff가 너무 길어질 것 같아 pagination 없이 이름만 로드할 수 있도록 구현했습니다.

## PR Checklist

- [x] 코드가 정상적으로 빌드되었나요?
- [ ] 적절한 테스트 코드가 추가되었나요? 추가되었다면 아래에 어떤 테스트인지 설명해 주세요.
- [x] 리뷰어 설정이 완료되었나요?

## Other

### Screenshots / Videos (Optional)

<img width="1905" height="1102" alt="2026-02-24-135819_hyprshot" src="https://github.com/user-attachments/assets/dbf91015-0934-46fd-8b47-ef815b4daf63" />
