### PR TITLE
feat: 신규 사용자 가입 시 슬랙 알림 보내는 기능 추가

### DIFF
--- a/apps/server/src/main/java/com/skkil/sync/common/integration/slack/SlackService.java
+++ b/apps/server/src/main/java/com/skkil/sync/common/integration/slack/SlackService.java
@@ -1,0 +1,36 @@
+package com.skkil.sync.common.integration.slack;
+
+import com.skkil.sync.common.integration.slack.dto.SlackMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+@Slf4j
+public class SlackService {
+
+  @Value("${app.slack.webhook-url}")
+  private String slackWebhookUrl;
+
+  private final RestClient restClient;
+
+  public SlackService() {
+    this.restClient = RestClient.builder().build();
+  }
+
+  public void sendMessage(SlackMessage message) {
+    ResponseEntity<Void> response =
+        restClient
+            .post()
+            .uri(slackWebhookUrl)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(message)
+            .retrieve()
+            .toBodilessEntity();
+    log.debug(
+        "Sent message to Slack: {}, response status: {}", message.text(), response.getStatusCode());
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/common/integration/slack/SlackService.java
+++ b/apps/server/src/main/java/com/skkil/sync/common/integration/slack/SlackService.java
@@ -7,6 +7,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 
 @Service
 @Slf4j
@@ -22,15 +23,28 @@ public class SlackService {
   }
 
   public void sendMessage(SlackMessage message) {
-    ResponseEntity<Void> response =
-        restClient
-            .post()
-            .uri(slackWebhookUrl)
-            .contentType(MediaType.APPLICATION_JSON)
-            .body(message)
-            .retrieve()
-            .toBodilessEntity();
-    log.debug(
-        "Sent message to Slack: {}, response status: {}", message.text(), response.getStatusCode());
+    if (slackWebhookUrl == null || slackWebhookUrl.isEmpty()) {
+      log.warn("Slack webhook URL is not configured. Skipping sending message: {}", message.text());
+      return;
+    }
+
+    try {
+      ResponseEntity<Void> response =
+          restClient
+              .post()
+              .uri(slackWebhookUrl)
+              .contentType(MediaType.APPLICATION_JSON)
+              .body(message)
+              .retrieve()
+              .toBodilessEntity();
+
+      log.debug(
+          "Sent message to Slack: {}, response status: {}",
+          message.text(),
+          response.getStatusCode());
+
+    } catch (RestClientException e) {
+      log.warn("Failed to send message to Slack: {}, error: {}", message.text(), e.getMessage());
+    }
   }
 }

--- a/apps/server/src/main/java/com/skkil/sync/common/integration/slack/dto/SlackMessage.java
+++ b/apps/server/src/main/java/com/skkil/sync/common/integration/slack/dto/SlackMessage.java
@@ -1,0 +1,3 @@
+package com.skkil.sync.common.integration.slack.dto;
+
+public record SlackMessage(String text) {}

--- a/apps/server/src/main/java/com/skkil/sync/user/listener/SlackUserRegisteredEventListener.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/listener/SlackUserRegisteredEventListener.java
@@ -1,0 +1,27 @@
+package com.skkil.sync.user.listener;
+
+import com.skkil.sync.common.integration.slack.SlackService;
+import com.skkil.sync.common.integration.slack.dto.SlackMessage;
+import com.skkil.sync.user.event.UserRegisteredEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@Slf4j
+public class SlackUserRegisteredEventListener {
+
+  private final SlackService slackService;
+
+  public SlackUserRegisteredEventListener(SlackService slackService) {
+    this.slackService = slackService;
+  }
+
+  @Async
+  @TransactionalEventListener
+  public void handleUserRegisteredEvent(UserRegisteredEvent event) {
+    log.debug("User registered event received for user ID: {}", event.getUserId());
+    slackService.sendMessage(new SlackMessage("새로운 사용자가 가입했습니다!"));
+  }
+}

--- a/apps/server/src/main/resources/application.yaml
+++ b/apps/server/src/main/resources/application.yaml
@@ -43,6 +43,8 @@ app:
   cors.allowed-origins: http://localhost:3000
   oauth2:
     frontend-redirect-uri: http://localhost:3000
+  slack:
+    webhook-url: ${SLACK_WEBHOOK_URL}
 
 server:
   servlet:

--- a/apps/server/src/main/resources/application.yaml
+++ b/apps/server/src/main/resources/application.yaml
@@ -44,7 +44,7 @@ app:
   oauth2:
     frontend-redirect-uri: http://localhost:3000
   slack:
-    webhook-url: ${SLACK_WEBHOOK_URL}
+    webhook-url: ${SLACK_WEBHOOK_URL:}
 
 server:
   servlet:

--- a/apps/server/src/main/resources/application.yaml
+++ b/apps/server/src/main/resources/application.yaml
@@ -27,8 +27,8 @@ spring:
       client:
         registration:
           google:
-            client-id: ${OAUTH2_CLIENT_REGISTRATION_GOOGLE_CLIENT_ID}
-            client-secret: ${OAUTH2_CLIENT_REGISTRATION_GOOGLE_CLIENT_SECRET}
+            client-id: ${OAUTH2_CLIENT_REGISTRATION_GOOGLE_CLIENT_ID:ID}
+            client-secret: ${OAUTH2_CLIENT_REGISTRATION_GOOGLE_CLIENT_SECRET:SECRET}
             scope:
               - openid
               - profile


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 신규 기능
- Related Issue: Closes #78

사용자가 새로 가입하면 슬랙 알림이 날라갈수 있도록 설정했습니다. 개발용 채널을 만들었으며 (아래 사진) 나중에 배포시 prod용 슬랙 채널을 따로 만들 예정입니다. 실행하기 위해서는 .env 파일에 SLACK_WEBHOOK_URL 파일을 추가해야하며 해당 파일 슬랙에 공유하겠습니다. async로 돌아가게 해서 SLACK_WEBHOOK_URL= 과 같이 빈 스트링으로 해도 실행에는 문제 없습니다.

## PR Checklist

- [x] 코드가 정상적으로 빌드되었나요?
- [ ] 적절한 테스트 코드가 추가되었나요? 추가되었다면 아래에 어떤 테스트인지 설명해 주세요.
- [x] 리뷰어 설정이 완료되었나요?

## Other

### Screenshots / Videos (Optional)

<img width="658" height="972" alt="2026-02-28-153727_hyprshot" src="https://github.com/user-attachments/assets/d056ac62-3474-4ff2-8fae-319c5ee2af49" />
