### PR TITLE
feat: 회사 채용 공고 등록 기능 추가

### DIFF
--- a/apps/server/src/main/java/com/skkil/sync/config/SecurityConfig.java
+++ b/apps/server/src/main/java/com/skkil/sync/config/SecurityConfig.java
@@ -46,6 +46,8 @@ public class SecurityConfig {
                     .hasRole("ADMIN")
                     .requestMatchers(HttpMethod.GET, "/experiences/**")
                     .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/companies/**")
+                    .permitAll()
                     .requestMatchers(HttpMethod.POST, "/providers/**")
                     .authenticated()
                     .requestMatchers("/users/**", "/profiles/me", "/media/**")
@@ -55,8 +57,7 @@ public class SecurityConfig {
                         "/auth/login",
                         "/auth/register",
                         "/providers/**",
-                        "/search/**",
-                        "/companies/**")
+                        "/search/**")
                     .permitAll()
                     .anyRequest()
                     .authenticated())

--- a/apps/server/src/main/java/com/skkil/sync/config/SecurityConfig.java
+++ b/apps/server/src/main/java/com/skkil/sync/config/SecurityConfig.java
@@ -55,7 +55,8 @@ public class SecurityConfig {
                         "/auth/login",
                         "/auth/register",
                         "/providers/**",
-                        "/search/**")
+                        "/search/**",
+                        "/companies/**")
                     .permitAll()
                     .anyRequest()
                     .authenticated())

--- a/apps/server/src/main/java/com/skkil/sync/provider/controller/CompanyController.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/controller/CompanyController.java
@@ -1,0 +1,37 @@
+package com.skkil.sync.provider.controller;
+
+import com.skkil.sync.provider.dto.request.CreateJobPostingRequest;
+import com.skkil.sync.provider.dto.response.CreateJobPostingResponse;
+import com.skkil.sync.provider.dto.response.GetJobPostingsResponse;
+import com.skkil.sync.provider.service.company.JobPostingService;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CompanyController {
+
+  private final JobPostingService jobPostingService;
+
+  public CompanyController(JobPostingService jobPostingService) {
+    this.jobPostingService = jobPostingService;
+  }
+
+  @PostMapping("/companies/{companyId}/jobs")
+  @ResponseStatus(HttpStatus.CREATED)
+  public CreateJobPostingResponse createJobPosting(
+      @PathVariable Long companyId, @RequestBody @Validated CreateJobPostingRequest request) {
+    return jobPostingService.createJobPosting(companyId, request);
+  }
+
+  @GetMapping("/companies/{companyId}/jobs")
+  @ResponseStatus(HttpStatus.OK)
+  public GetJobPostingsResponse getJobPostings(@PathVariable Long companyId) {
+    return jobPostingService.getJobPostings(companyId);
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/provider/dto/request/CreateJobPostingRequest.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/dto/request/CreateJobPostingRequest.java
@@ -1,0 +1,9 @@
+package com.skkil.sync.provider.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateJobPostingRequest(
+    @NotNull @Size(min = 1, max = 255) String jobTitle,
+    @NotNull String jobDescription,
+    @Size(max = 255) String location) {}

--- a/apps/server/src/main/java/com/skkil/sync/provider/dto/request/CreateJobPostingRequest.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/dto/request/CreateJobPostingRequest.java
@@ -1,9 +1,9 @@
 package com.skkil.sync.provider.dto.request;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record CreateJobPostingRequest(
-    @NotNull @Size(min = 1, max = 255) String jobTitle,
-    @NotNull String jobDescription,
+    @NotBlank @Size(max = 255) String jobTitle,
+    @NotBlank String jobDescription,
     @Size(max = 255) String location) {}

--- a/apps/server/src/main/java/com/skkil/sync/provider/dto/response/CreateJobPostingResponse.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/dto/response/CreateJobPostingResponse.java
@@ -1,0 +1,3 @@
+package com.skkil.sync.provider.dto.response;
+
+public record CreateJobPostingResponse(Long id) {}

--- a/apps/server/src/main/java/com/skkil/sync/provider/dto/response/CreateJobPostingResponse.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/dto/response/CreateJobPostingResponse.java
@@ -1,3 +1,3 @@
 package com.skkil.sync.provider.dto.response;
 
-public record CreateJobPostingResponse(Long id) {}
+public record CreateJobPostingResponse(String id) {}

--- a/apps/server/src/main/java/com/skkil/sync/provider/dto/response/GetJobPostingsResponse.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/dto/response/GetJobPostingsResponse.java
@@ -1,0 +1,17 @@
+package com.skkil.sync.provider.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record GetJobPostingsResponse(List<JobPosting> postings) {
+
+  public static record JobPosting(
+      Long id,
+      String jobTitle,
+      String jobDescription,
+      String location,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt) {}
+}

--- a/apps/server/src/main/java/com/skkil/sync/provider/dto/response/GetJobPostingsResponse.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/dto/response/GetJobPostingsResponse.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 public record GetJobPostingsResponse(List<JobPosting> postings) {
 
   public static record JobPosting(
-      Long id,
+      String id,
       String jobTitle,
       String jobDescription,
       String location,

--- a/apps/server/src/main/java/com/skkil/sync/provider/mapper/CompanyMapper.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/mapper/CompanyMapper.java
@@ -1,0 +1,17 @@
+package com.skkil.sync.provider.mapper;
+
+import com.skkil.sync.provider.dto.response.GetJobPostingsResponse;
+import com.skkil.sync.provider.model.company.JobPosting;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface CompanyMapper {
+
+  GetJobPostingsResponse.JobPosting toJobPostingResponse(JobPosting jobPosting);
+
+  default LocalDateTime toLocalDateTime(Instant instant) {
+    return LocalDateTime.ofInstant(instant, java.time.ZoneId.systemDefault());
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/provider/model/company/Company.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/model/company/Company.java
@@ -1,6 +1,7 @@
-package com.skkil.sync.provider.model;
+package com.skkil.sync.provider.model.company;
 
 import com.skkil.sync.provider.constant.ProviderType;
+import com.skkil.sync.provider.model.Provider;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;

--- a/apps/server/src/main/java/com/skkil/sync/provider/model/company/JobPosting.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/model/company/JobPosting.java
@@ -1,0 +1,55 @@
+package com.skkil.sync.provider.model.company;
+
+import com.skkil.sync.common.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Table(name = "job_postings")
+@Getter
+public class JobPosting extends BaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "company_id", nullable = false)
+  private Company company;
+
+  @Column(name = "job_title")
+  private String jobTitle;
+
+  @Column(name = "job_description", columnDefinition = "TEXT")
+  private String jobDescription;
+
+  @Column(name = "location")
+  private String location;
+
+  protected JobPosting() {}
+
+  @Builder
+  public JobPosting(Company company, String jobTitle, String jobDescription, String location) {
+    this.company = company;
+    this.jobTitle = jobTitle;
+    this.jobDescription = jobDescription;
+    this.location = location;
+  }
+
+  public void updateFields(
+      String jobTitle, String jobDescription, String qualifications, String location) {
+    if (jobTitle != null) {
+      this.jobTitle = jobTitle;
+    }
+
+    if (jobDescription != null) {
+      this.jobDescription = jobDescription;
+    }
+
+    if (location != null) {
+      this.location = location;
+    }
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/provider/model/company/JobPosting.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/model/company/JobPosting.java
@@ -19,10 +19,10 @@ public class JobPosting extends BaseEntity {
   @JoinColumn(name = "company_id", nullable = false)
   private Company company;
 
-  @Column(name = "job_title")
+  @Column(name = "job_title", nullable = false)
   private String jobTitle;
 
-  @Column(name = "job_description", columnDefinition = "TEXT")
+  @Column(name = "job_description", columnDefinition = "TEXT", nullable = false)
   private String jobDescription;
 
   @Column(name = "location")
@@ -38,8 +38,7 @@ public class JobPosting extends BaseEntity {
     this.location = location;
   }
 
-  public void updateFields(
-      String jobTitle, String jobDescription, String qualifications, String location) {
+  public void updateFields(String jobTitle, String jobDescription, String location) {
     if (jobTitle != null) {
       this.jobTitle = jobTitle;
     }

--- a/apps/server/src/main/java/com/skkil/sync/provider/repository/company/CompanyRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/repository/company/CompanyRepository.java
@@ -1,0 +1,6 @@
+package com.skkil.sync.provider.repository.company;
+
+import com.skkil.sync.provider.model.company.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CompanyRepository extends JpaRepository<Company, Long> {}

--- a/apps/server/src/main/java/com/skkil/sync/provider/repository/company/JobPostingRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/repository/company/JobPostingRepository.java
@@ -1,0 +1,13 @@
+package com.skkil.sync.provider.repository.company;
+
+import com.skkil.sync.provider.model.company.Company;
+import com.skkil.sync.provider.model.company.JobPosting;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface JobPostingRepository extends JpaRepository<JobPosting, Long> {
+
+  @Query("SELECT jp FROM JobPosting jp WHERE jp.company = :company")
+  List<JobPosting> findByCompany(Company company);
+}

--- a/apps/server/src/main/java/com/skkil/sync/provider/service/ProviderStrategy.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/service/ProviderStrategy.java
@@ -6,7 +6,7 @@ import com.skkil.sync.provider.dto.request.UpdateProviderRequest;
 import com.skkil.sync.provider.dto.response.GetProviderResponse;
 import com.skkil.sync.provider.model.Provider;
 
-interface ProviderStrategy {
+public interface ProviderStrategy {
 
   ProviderType getProviderType();
 

--- a/apps/server/src/main/java/com/skkil/sync/provider/service/company/CompanyService.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/service/company/CompanyService.java
@@ -1,4 +1,4 @@
-package com.skkil.sync.provider.service;
+package com.skkil.sync.provider.service.company;
 
 import com.skkil.sync.provider.constant.ProviderType;
 import com.skkil.sync.provider.dto.request.CreateCompanyRequest;
@@ -7,15 +7,16 @@ import com.skkil.sync.provider.dto.request.UpdateCompanyRequest;
 import com.skkil.sync.provider.dto.request.UpdateProviderRequest;
 import com.skkil.sync.provider.dto.response.GetCompanyResponse;
 import com.skkil.sync.provider.dto.response.GetProviderResponse;
-import com.skkil.sync.provider.model.Company;
 import com.skkil.sync.provider.model.Provider;
+import com.skkil.sync.provider.model.company.Company;
+import com.skkil.sync.provider.service.ProviderStrategy;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-class CompanyService implements ProviderStrategy {
+public class CompanyService implements ProviderStrategy {
 
   @Override
   public ProviderType getProviderType() {

--- a/apps/server/src/main/java/com/skkil/sync/provider/service/company/JobPostingService.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/service/company/JobPostingService.java
@@ -1,0 +1,66 @@
+package com.skkil.sync.provider.service.company;
+
+import com.skkil.sync.provider.dto.request.CreateJobPostingRequest;
+import com.skkil.sync.provider.dto.response.CreateJobPostingResponse;
+import com.skkil.sync.provider.dto.response.GetJobPostingsResponse;
+import com.skkil.sync.provider.mapper.CompanyMapper;
+import com.skkil.sync.provider.model.company.Company;
+import com.skkil.sync.provider.model.company.JobPosting;
+import com.skkil.sync.provider.repository.company.CompanyRepository;
+import com.skkil.sync.provider.repository.company.JobPostingRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+public class JobPostingService {
+
+  private final CompanyRepository companyRepository;
+  private final JobPostingRepository jobPostingRepository;
+  private final CompanyMapper companyMapper;
+
+  public JobPostingService(
+      CompanyRepository companyRepository,
+      JobPostingRepository jobPostingRepository,
+      CompanyMapper companyMapper) {
+    this.companyRepository = companyRepository;
+    this.jobPostingRepository = jobPostingRepository;
+    this.companyMapper = companyMapper;
+  }
+
+  @Transactional
+  @PreAuthorize("hasPermission(#companyId, 'PROVIDER', 'EDIT')")
+  public CreateJobPostingResponse createJobPosting(
+      Long companyId, CreateJobPostingRequest request) {
+    Company company = companyRepository.getReferenceById(companyId);
+
+    JobPosting jobPosting =
+        JobPosting.builder()
+            .company(company)
+            .jobTitle(request.jobTitle())
+            .jobDescription(request.jobDescription())
+            .location(request.location())
+            .build();
+
+    jobPosting = jobPostingRepository.save(jobPosting);
+    log.debug("Created job posting with id {} for company {}", jobPosting.getId(), companyId);
+
+    return new CreateJobPostingResponse(jobPosting.getId());
+  }
+
+  @Transactional(readOnly = true)
+  @PreAuthorize("hasPermission(#companyId, 'PROVIDER', 'READ')")
+  public GetJobPostingsResponse getJobPostings(Long companyId) {
+    Company company = companyRepository.getReferenceById(companyId);
+
+    var postings =
+        jobPostingRepository.findByCompany(company).stream()
+            .map(companyMapper::toJobPostingResponse)
+            .toList();
+
+    log.debug("Retrieved {} job postings for company {}", postings.size(), companyId);
+    return new GetJobPostingsResponse(postings);
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/provider/service/company/JobPostingService.java
+++ b/apps/server/src/main/java/com/skkil/sync/provider/service/company/JobPostingService.java
@@ -47,7 +47,7 @@ public class JobPostingService {
     jobPosting = jobPostingRepository.save(jobPosting);
     log.debug("Created job posting with id {} for company {}", jobPosting.getId(), companyId);
 
-    return new CreateJobPostingResponse(jobPosting.getId());
+    return new CreateJobPostingResponse(jobPosting.getId().toString());
   }
 
   @Transactional(readOnly = true)

--- a/apps/server/src/main/java/com/skkil/sync/review/model/CompanyReview.java
+++ b/apps/server/src/main/java/com/skkil/sync/review/model/CompanyReview.java
@@ -1,7 +1,7 @@
 package com.skkil.sync.review.model;
 
 import com.skkil.sync.provider.constant.ProviderType;
-import com.skkil.sync.provider.model.Company;
+import com.skkil.sync.provider.model.company.Company;
 import com.skkil.sync.user.model.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/apps/server/src/main/resources/db/changelog/changesets/00014-create-table-job-postings.yaml
+++ b/apps/server/src/main/resources/db/changelog/changesets/00014-create-table-job-postings.yaml
@@ -5,7 +5,7 @@ databaseChangeLog:
       preConditions:
         - not:
             tableExists:
-              tableName: job-postings
+              tableName: job_postings
       changes:
         - createTable:
             tableName: job_postings
@@ -32,9 +32,13 @@ databaseChangeLog:
               - column:
                   name: job_title
                   type: VARCHAR(255)
+                  constraints:
+                    nullable: false
               - column:
                   name: job_description
                   type: TEXT
+                  constraints:
+                    nullable: false
               - column:
                   name: location
                   type: VARCHAR(255)

--- a/apps/server/src/main/resources/db/changelog/changesets/00014-create-table-job-postings.yaml
+++ b/apps/server/src/main/resources/db/changelog/changesets/00014-create-table-job-postings.yaml
@@ -1,0 +1,47 @@
+databaseChangeLog:
+  - changeSet:
+      id: 00014-create-table-job-postings
+      author: hyoungjoojin
+      preConditions:
+        - not:
+            tableExists:
+              tableName: job-postings
+      changes:
+        - createTable:
+            tableName: job_postings
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  defaultValueComputed: CURRENT_TIMESTAMP
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP
+                  defaultValueComputed: CURRENT_TIMESTAMP
+              - column:
+                  name: company_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: job_title
+                  type: VARCHAR(255)
+              - column:
+                  name: job_description
+                  type: TEXT
+              - column:
+                  name: location
+                  type: VARCHAR(255)
+        - addForeignKeyConstraint:
+            baseTableName: job_postings
+            baseColumnNames: company_id
+            referencedTableName: companies
+            referencedColumnNames: id
+            constraintName: fk_job_postings_company_id
+            onDelete: CASCADE

--- a/apps/server/src/test/java/com/skkil/sync/provider/controller/CompanyControllerTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/provider/controller/CompanyControllerTests.java
@@ -43,7 +43,7 @@ public class CompanyControllerTests {
     CreateJobPostingRequest request =
         new CreateJobPostingRequest("Job Title", "Job Description", "Location");
 
-    CreateJobPostingResponse response = new CreateJobPostingResponse(1L);
+    CreateJobPostingResponse response = new CreateJobPostingResponse("1");
     Mockito.when(jobPostingService.createJobPosting(any(), any())).thenReturn(response);
 
     mockMvc
@@ -61,7 +61,7 @@ public class CompanyControllerTests {
         new GetJobPostingsResponse(
             List.of(
                 new GetJobPostingsResponse.JobPosting(
-                    1L,
+                    "1",
                     "",
                     "",
                     "",

--- a/apps/server/src/test/java/com/skkil/sync/provider/controller/CompanyControllerTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/provider/controller/CompanyControllerTests.java
@@ -1,0 +1,74 @@
+package com.skkil.sync.provider.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.skkil.sync.provider.dto.request.CreateJobPostingRequest;
+import com.skkil.sync.provider.dto.response.CreateJobPostingResponse;
+import com.skkil.sync.provider.dto.response.GetJobPostingsResponse;
+import com.skkil.sync.provider.service.company.JobPostingService;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.json.JsonMapper;
+
+@WebMvcTest(CompanyController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
+@ExtendWith(RestDocumentationExtension.class)
+public class CompanyControllerTests {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private JobPostingService jobPostingService;
+
+  @Autowired private JsonMapper jsonMapper;
+
+  @Test
+  void createJobPosting() throws Exception {
+    CreateJobPostingRequest request =
+        new CreateJobPostingRequest("Job Title", "Job Description", "Location");
+
+    CreateJobPostingResponse response = new CreateJobPostingResponse(1L);
+    Mockito.when(jobPostingService.createJobPosting(any(), any())).thenReturn(response);
+
+    mockMvc
+        .perform(
+            post("/companies/{companyId}/jobs", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonMapper.writeValueAsString(request))
+                .with(csrf()))
+        .andExpect(status().isCreated());
+  }
+
+  @Test
+  void getJobPostings() throws Exception {
+    GetJobPostingsResponse response =
+        new GetJobPostingsResponse(
+            List.of(
+                new GetJobPostingsResponse.JobPosting(
+                    1L,
+                    "",
+                    "",
+                    "",
+                    LocalDateTime.now(ZoneId.systemDefault()),
+                    LocalDateTime.now(ZoneId.systemDefault()))));
+    Mockito.when(jobPostingService.getJobPostings(any())).thenReturn(response);
+
+    mockMvc.perform(get("/companies/{companyId}/jobs", 1L)).andExpect(status().isOk());
+  }
+}

--- a/apps/web/public/locales/ko.json
+++ b/apps/web/public/locales/ko.json
@@ -198,7 +198,7 @@
           "posted-date": "게시 날짜"
         },
         "modal": {
-          "posted-on": "게시 날짜: "
+          "posted-on": "게시 날짜"
         },
         "create-posting": {
           "form": {

--- a/apps/web/public/locales/ko.json
+++ b/apps/web/public/locales/ko.json
@@ -169,6 +169,7 @@
         "about": "소개",
         "people": "관련 인물",
         "reviews": "리뷰",
+        "jobs": "채용 공고",
         "occurrences": "회차"
       },
       "admin": {
@@ -182,9 +183,54 @@
     "provider-admin": {
       "sections": {
         "about": "소개",
-        "settings": "설정"
+        "settings": "설정",
+        "job-postings": "채용 공고"
       },
       "view-as-member": "일반 사용자로 보기"
+    },
+    "company": {
+      "job-postings": {
+        "title": "채용 공고",
+        "table": {
+          "empty": "이 회사에는 현재 채용 공고가 없습니다.",
+          "job-title": "직책",
+          "location": "근무 지역",
+          "posted-date": "게시 날짜"
+        },
+        "modal": {
+          "posted-on": "게시 날짜: "
+        },
+        "create-posting": {
+          "form": {
+            "label": "채용 공고 만들기",
+            "title": "채용 공고 만들기",
+            "description": "이 회사에 대한 새로운 채용 공고를 작성하세요",
+            "job-title": {
+              "label": "직책",
+              "placeholder": "예: 소프트웨어 엔지니어"
+            },
+            "job-description": {
+              "label": "직무 설명",
+              "placeholder": "이 직책에 대한 자세한 설명을 입력하세요"
+            },
+            "location": {
+              "label": "근무 지역",
+              "placeholder": "예: 서울시 강남구"
+            },
+            "submit": {
+              "label": "채용 공고 제출"
+            },
+            "messages": {
+              "success": "채용 공고가 성공적으로 생성되었습니다.",
+              "error": "채용 공고 생성에 실패했습니다."
+            },
+            "errors": {
+              "required-job-title": "직책은 필수 항목입니다.",
+              "required-job-description": "직무 설명은 필수 항목입니다."
+            }
+          }
+        }
+      }
     },
     "search": {
       "results": {

--- a/apps/web/src/app/(app)/company/[id]/admin/page.tsx
+++ b/apps/web/src/app/(app)/company/[id]/admin/page.tsx
@@ -1,4 +1,7 @@
+import { getTranslations } from 'next-intl/server';
+
 import ProviderAdminPage from '@/features/provider/components/ProviderAdminPage';
+import JobPostingsAdmin from '@/features/provider/components/company/JobPostingsAdmin';
 import { ProviderType } from '@/types/provider';
 
 interface CompanyProps {
@@ -8,7 +11,21 @@ interface CompanyProps {
 }
 
 export default async function CompanyAdmin({ params }: CompanyProps) {
+  const t = await getTranslations('pages.provider-admin');
+
   const { id } = await params;
 
-  return <ProviderAdminPage id={id} providerType={ProviderType.COMPANY} />;
+  return (
+    <ProviderAdminPage
+      id={id}
+      providerType={ProviderType.COMPANY}
+      additionalTabs={[
+        {
+          id: 'jobs',
+          title: t('sections.job-postings'),
+          content: <JobPostingsAdmin id={id} />,
+        },
+      ]}
+    />
+  );
 }

--- a/apps/web/src/app/(app)/company/[id]/page.tsx
+++ b/apps/web/src/app/(app)/company/[id]/page.tsx
@@ -16,6 +16,7 @@ import ProviderAbout from '@/features/provider/components/ProviderAbout';
 import ProviderOverview from '@/features/provider/components/ProviderOverview';
 import ProviderRelatedPeople from '@/features/provider/components/ProviderPeople';
 import ProviderReviews from '@/features/provider/components/ProviderReviews';
+import JobPostings from '@/features/provider/components/company/JobPostings';
 import SyncError, { ErrorCode } from '@/lib/error';
 import { getQueryClient } from '@/lib/query';
 import { ProviderType } from '@/types/provider';
@@ -57,6 +58,11 @@ export default async function Company({ params, searchParams }: CompanyProps) {
       id: 'about',
       title: t('sections.about'),
       content: <ProviderAbout />,
+    },
+    {
+      id: 'jobs',
+      title: t('sections.jobs'),
+      content: <JobPostings id={id} />,
     },
     {
       id: 'people',
@@ -113,7 +119,7 @@ export default async function Company({ params, searchParams }: CompanyProps) {
 
             <Card className="min-h-96 overflow-auto">
               {tabs.map((tab) => (
-                <TabsContent key={tab.id} value={tab.id}>
+                <TabsContent key={tab.id} value={tab.id} className="px-5">
                   {tab.content}
                 </TabsContent>
               ))}

--- a/apps/web/src/components/ui/data-table.tsx
+++ b/apps/web/src/components/ui/data-table.tsx
@@ -23,12 +23,14 @@ interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
   t: Translations;
+  onRowClick?: (row: TData) => void;
 }
 
 export function DataTable<TData, TValue>({
   columns,
   data,
   t,
+  onRowClick,
 }: DataTableProps<TData, TValue>) {
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
@@ -67,6 +69,7 @@ export function DataTable<TData, TValue>({
               <TableRow
                 key={row.id}
                 data-state={row.getIsSelected() && 'selected'}
+                onClick={() => onRowClick?.(row.original)}
               >
                 {row.getVisibleCells().map((cell) => (
                   <TableCell key={cell.id}>
@@ -98,6 +101,14 @@ interface DataTableColumnHeaderProps<
 
 export function DataTableColumnHeader<TData, TValue>({
   title,
-}: DataTableColumnHeaderProps<TData, TValue>) {
-  return <>{title}</>;
+  icon,
+}: DataTableColumnHeaderProps<TData, TValue> & {
+  icon?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      {icon && icon}
+      {title}
+    </div>
+  );
 }

--- a/apps/web/src/components/ui/data-table.tsx
+++ b/apps/web/src/components/ui/data-table.tsx
@@ -102,11 +102,12 @@ interface DataTableColumnHeaderProps<
 export function DataTableColumnHeader<TData, TValue>({
   title,
   icon,
+  ...props
 }: DataTableColumnHeaderProps<TData, TValue> & {
   icon?: React.ReactNode;
 }) {
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-2" {...props}>
       {icon && icon}
       {title}
     </div>

--- a/apps/web/src/features/provider/api/company/create-job-posting.ts
+++ b/apps/web/src/features/provider/api/company/create-job-posting.ts
@@ -27,5 +27,10 @@ export function useCreateJobPostingMutation(companyId: string) {
   return useMutation({
     mutationFn: (request: CreateJobPostingRequest) =>
       createJobPosting(companyId, request),
+    onSuccess: (_data, _variables, _onMutateResult, context) => {
+      context.client.invalidateQueries({
+        queryKey: ['company', companyId, 'job-postings'],
+      });
+    },
   });
 }

--- a/apps/web/src/features/provider/api/company/create-job-posting.ts
+++ b/apps/web/src/features/provider/api/company/create-job-posting.ts
@@ -1,0 +1,31 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { server } from '@/lib/server';
+
+type CreateJobPostingRequest = {
+  jobTitle: string;
+  jobDescription: string;
+  location?: string;
+};
+
+type CreateJobPostingResponse = {
+  id: string;
+};
+
+async function createJobPosting(
+  companyId: string,
+  request: CreateJobPostingRequest,
+) {
+  return server
+    .post<CreateJobPostingResponse>(`companies/${companyId}/jobs`, {
+      json: request,
+    })
+    .json();
+}
+
+export function useCreateJobPostingMutation(companyId: string) {
+  return useMutation({
+    mutationFn: (request: CreateJobPostingRequest) =>
+      createJobPosting(companyId, request),
+  });
+}

--- a/apps/web/src/features/provider/api/company/get-job-postings.ts
+++ b/apps/web/src/features/provider/api/company/get-job-postings.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { server } from '@/lib/server';
+
+interface GetJobPostingsResponse {
+  postings: {
+    id: string;
+    jobTitle: string;
+    jobDescription: string;
+    location: string;
+    createdAt: string;
+  }[];
+}
+
+async function getJobPostings(companyId: string) {
+  return server
+    .get<GetJobPostingsResponse>(`companies/${companyId}/jobs`)
+    .json()
+    .then((data) => data.postings);
+}
+
+export function useGetJobPostingsQuery(companyId: string) {
+  return useQuery({
+    queryKey: ['company', companyId, 'job-postings'],
+    queryFn: () => getJobPostings(companyId),
+    enabled: !!companyId,
+  });
+}

--- a/apps/web/src/features/provider/components/ProviderAdminLayout.tsx
+++ b/apps/web/src/features/provider/components/ProviderAdminLayout.tsx
@@ -53,7 +53,7 @@ export default function ProviderAdminLayout({
 
           <Card className="min-h-96 overflow-auto">
             {tabs.map((tab) => (
-              <TabsContent key={tab.id} value={tab.id}>
+              <TabsContent key={tab.id} value={tab.id} className="px-5">
                 {tab.content}
               </TabsContent>
             ))}

--- a/apps/web/src/features/provider/components/ProviderAdminPage.tsx
+++ b/apps/web/src/features/provider/components/ProviderAdminPage.tsx
@@ -50,20 +50,19 @@ export default async function ProviderAdminPage({
     redirect(providerPath);
   }
 
-  const baseTabs: Tab[] = [
+  const tabs = [
     {
       id: 'about',
       title: t('sections.about'),
       content: <ProviderAbout />,
     },
+    ...additionalTabs,
     {
       id: 'settings',
       title: t('sections.settings'),
       content: <div></div>,
     },
   ];
-
-  const tabs = [...baseTabs, ...additionalTabs];
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/apps/web/src/features/provider/components/company/CreateJobPostingForm.tsx
+++ b/apps/web/src/features/provider/components/company/CreateJobPostingForm.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { PlusIcon } from '@phosphor-icons/react';
+import { useTranslations } from 'next-intl';
+import { useMemo, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import z from 'zod';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+
+import { useCreateJobPostingMutation } from '../../api/company/create-job-posting';
+
+interface CreateJobFormProps {
+  companyId: string;
+}
+
+const createJobFormSchema = (t: (key: string) => string) =>
+  z.object({
+    jobTitle: z.string().min(1, t('errors.required-job-title')),
+    jobDescription: z.string().min(1, t('errors.required-job-description')),
+    location: z.string().optional(),
+  });
+
+type CreateJobFormValues = z.infer<ReturnType<typeof createJobFormSchema>>;
+
+export default function CreateJobPostingForm({
+  companyId: providerId,
+}: CreateJobFormProps) {
+  const t = useTranslations('pages.company.job-postings.create-posting.form');
+
+  const schema = useMemo(() => createJobFormSchema(t), [t]);
+  const { mutate: createJob, isPending } =
+    useCreateJobPostingMutation(providerId);
+
+  const form = useForm<CreateJobFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      jobTitle: '',
+      jobDescription: '',
+      location: '',
+    },
+  });
+
+  const [open, setOpen] = useState(false);
+
+  const formSubmitHandler = (values: CreateJobFormValues) => {
+    createJob(values, {
+      onSuccess: () => {
+        toast.success(t('messages.success'));
+        form.reset();
+        setOpen(false);
+      },
+      onError: () => {
+        toast.error(t('messages.error'));
+      },
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>
+          <PlusIcon />
+          {t('label')}
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('title')}</DialogTitle>
+          <DialogDescription>{t('description')}</DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={form.handleSubmit(formSubmitHandler)}>
+          <FieldGroup>
+            <Controller
+              name="jobTitle"
+              control={form.control}
+              render={({ field, fieldState }) => (
+                <Field>
+                  <div className="flex items-center justify-between">
+                    <FieldLabel>{t('job-title.label')}</FieldLabel>
+                    <FieldError errors={[fieldState.error]} />
+                  </div>
+                  <Input
+                    {...field}
+                    aria-invalid={fieldState.invalid}
+                    placeholder={t('job-title.placeholder')}
+                  />
+                </Field>
+              )}
+            />
+
+            <Controller
+              name="jobDescription"
+              control={form.control}
+              render={({ field, fieldState }) => (
+                <Field>
+                  <div className="flex items-center justify-between">
+                    <FieldLabel>{t('job-description.label')}</FieldLabel>
+                    <FieldError errors={[fieldState.error]} />
+                  </div>
+                  <Textarea
+                    {...field}
+                    aria-invalid={fieldState.invalid}
+                    placeholder={t('job-description.placeholder')}
+                    rows={5}
+                  />
+                </Field>
+              )}
+            />
+
+            <Controller
+              name="location"
+              control={form.control}
+              render={({ field, fieldState }) => (
+                <Field>
+                  <div className="flex items-center justify-between">
+                    <FieldLabel>{t('location.label')}</FieldLabel>
+                    <FieldError errors={[fieldState.error]} />
+                  </div>
+                  <Input
+                    {...field}
+                    aria-invalid={fieldState.invalid}
+                    placeholder={t('location.placeholder')}
+                  />
+                </Field>
+              )}
+            />
+
+            <DialogFooter>
+              <Button type="submit" disabled={isPending}>
+                {t('submit.label')}
+              </Button>
+            </DialogFooter>
+          </FieldGroup>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/provider/components/company/JobPostingModal.tsx
+++ b/apps/web/src/features/provider/components/company/JobPostingModal.tsx
@@ -40,7 +40,11 @@ export default function JobPostingModal({
                 {jobPosting.jobTitle}
               </DialogTitle>
               <DialogDescription className="flex items-center gap-2">
-                <span>{jobPosting.location}</span>|
+                {jobPosting.location && (
+                  <>
+                    <span>{jobPosting.location}</span>|
+                  </>
+                )}
                 <span>
                   {t('posted-on')}{' '}
                   {new Date(jobPosting.createdAt).toLocaleDateString()}

--- a/apps/web/src/features/provider/components/company/JobPostingModal.tsx
+++ b/apps/web/src/features/provider/components/company/JobPostingModal.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+import { JobPosting } from './JobPostingsTableColumns';
+
+interface JobPostingModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  jobPosting: JobPosting | null;
+}
+
+export default function JobPostingModal({
+  jobPosting,
+  open,
+  onOpenChange,
+}: JobPostingModalProps) {
+  const t = useTranslations('pages.company.job-postings.modal');
+
+  if (!jobPosting) {
+    return null;
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-11/12 sm:max-w-4xl min-h-[60vh] max-h-[90vh] overflow-y-auto flex flex-col">
+        <DialogHeader>
+          <div className="flex justify-between items-center">
+            <div className="flex flex-col gap-2">
+              <DialogTitle className="text-2xl">
+                {jobPosting.jobTitle}
+              </DialogTitle>
+              <DialogDescription className="flex items-center gap-2">
+                <span>{jobPosting.location}</span>|
+                <span>
+                  {t('posted-on')}{' '}
+                  {new Date(jobPosting.createdAt).toLocaleDateString()}
+                </span>
+              </DialogDescription>
+            </div>
+
+            <DialogClose />
+          </div>
+        </DialogHeader>
+
+        <div className="space-y-4 grow">
+          <div>
+            <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+              {jobPosting.jobDescription}
+            </p>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/provider/components/company/JobPostings.tsx
+++ b/apps/web/src/features/provider/components/company/JobPostings.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import JobPostingsTable from './JobPostingsTable';
+
+interface JobPostingsProps {
+  id: string;
+}
+
+export default function JobPostings({ id }: JobPostingsProps) {
+  const t = useTranslations('pages.company.job-postings');
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-5">
+        <h1 className="text-xl">{t('title')}</h1>
+      </div>
+
+      <JobPostingsTable companyId={id} />
+    </div>
+  );
+}

--- a/apps/web/src/features/provider/components/company/JobPostingsAdmin.tsx
+++ b/apps/web/src/features/provider/components/company/JobPostingsAdmin.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import CreateJobPostingForm from './CreateJobPostingForm';
+import JobPostingsTable from './JobPostingsTable';
+
+interface JobPostingsAdminProps {
+  id: string;
+}
+
+export default function JobPostingsAdmin({ id }: JobPostingsAdminProps) {
+  const t = useTranslations('pages.company.job-postings');
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-5">
+        <h1 className="text-xl">{t('title')}</h1>
+        <CreateJobPostingForm companyId={id} />
+      </div>
+
+      <JobPostingsTable companyId={id} />
+    </div>
+  );
+}

--- a/apps/web/src/features/provider/components/company/JobPostingsTable.tsx
+++ b/apps/web/src/features/provider/components/company/JobPostingsTable.tsx
@@ -1,0 +1,42 @@
+import { useTranslations } from 'next-intl';
+import { useState } from 'react';
+
+import { DataTable } from '@/components/ui/data-table';
+
+import { useGetJobPostingsQuery } from '../../api/company/get-job-postings';
+import JobPostingModal from './JobPostingModal';
+import { JobPosting, columns } from './JobPostingsTableColumns';
+
+interface JobPostingsTableProps {
+  companyId: string;
+}
+
+export default function JobPostingsTable({ companyId }: JobPostingsTableProps) {
+  const t = useTranslations('pages.company.job-postings.table');
+
+  const { data: jobPostings } = useGetJobPostingsQuery(companyId);
+
+  const [open, setOpen] = useState(false);
+  const [selectedJobPosting, setSelectedJobPosting] =
+    useState<JobPosting | null>(null);
+
+  return (
+    <>
+      <DataTable
+        columns={columns}
+        data={jobPostings || []}
+        t={t}
+        onRowClick={(row) => {
+          setSelectedJobPosting(row);
+          setOpen(true);
+        }}
+      />
+
+      <JobPostingModal
+        jobPosting={selectedJobPosting}
+        open={open}
+        onOpenChange={setOpen}
+      />
+    </>
+  );
+}

--- a/apps/web/src/features/provider/components/company/JobPostingsTableColumns.tsx
+++ b/apps/web/src/features/provider/components/company/JobPostingsTableColumns.tsx
@@ -1,0 +1,35 @@
+import { MapPinIcon, SuitcaseSimpleIcon } from '@phosphor-icons/react';
+import { ColumnDef } from '@tanstack/react-table';
+
+import { DataTableColumnHeader } from '@/components/ui/data-table';
+
+export type JobPosting = {
+  id: string;
+  jobTitle: string;
+  jobDescription: string;
+  location: string;
+  createdAt: string;
+};
+
+export const columns: ColumnDef<JobPosting>[] = [
+  {
+    accessorKey: 'jobTitle',
+    header: ({ column, table }) => (
+      <DataTableColumnHeader
+        icon={<SuitcaseSimpleIcon />}
+        title={table.options.meta?.t('job-title') || ''}
+        column={column}
+      />
+    ),
+  },
+  {
+    accessorKey: 'location',
+    header: ({ column, table }) => (
+      <DataTableColumnHeader
+        icon={<MapPinIcon />}
+        title={table.options.meta?.t('location') || ''}
+        column={column}
+      />
+    ),
+  },
+];


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 신규 기능
- Related Issue: Closes #97

채용 공고를 등록하고 확인할 수 있도록 기능을 추가했습니다.

DB 모델에는 JobPosting이라는 새로운 테이블을 만들었습니다.
서버측에는 /companies/{companyId}/jobs에 새로운 API를 만들었고 GET과 POST만 개발했습니다.

웹에서는 이전에 추가했었던 DataTable component를 사용해서 채용 공고 리스트를 표시하도록 했으며, 각 row를 클릭하면 모달이 표시되도록 개발했습니다.

## PR Checklist

- [x] 코드가 정상적으로 빌드되었나요?
- [x] 적절한 테스트 코드가 추가되었나요? 추가되었다면 아래에 어떤 테스트인지 설명해 주세요.
  - [x] 서버 controller에 status code만 체크하는 테스트를 추가했습니다.
- [x] 리뷰어 설정이 완료되었나요?

## Other

### 참고사항

- 이후에 공고에 대한 pagination을 개발해야합니다.
- 현재 모달에는 기본적인 정보만 있어서 후에 정보들을 추가해야합니다.

### Screenshots / Videos (Optional)

<img width="1897" height="1097" alt="2026-03-06-170719_hyprshot" src="https://github.com/user-attachments/assets/65dab6fe-e0ce-4dd8-83f7-f886372ce4d0" />
<img width="1892" height="1094" alt="2026-03-06-170739_hyprshot" src="https://github.com/user-attachments/assets/22f38438-24de-41a5-a23e-2d00485c046e" />
<img width="1902" height="1093" alt="2026-03-06-170822_hyprshot" src="https://github.com/user-attachments/assets/0684734e-e40f-4c7a-b204-3d1d93834380" />
