### PR TITLE
fix: provider 검증 시 토스트 추가, provider 리스트 업데이트

### DIFF
--- a/apps/web/public/locales/ko.json
+++ b/apps/web/public/locales/ko.json
@@ -588,6 +588,10 @@
         "description": "기관을 검토하고 검증하세요",
         "actions": {
           "verify": "검증"
+        },
+        "messages": {
+          "success": "기관 검증이 완료되었습니다.",
+          "error": "기관 검증에 실패했습니다."
         }
       }
     },

--- a/apps/web/src/app/admin/_components/UnverifiedProviders.tsx
+++ b/apps/web/src/app/admin/_components/UnverifiedProviders.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
+import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -29,18 +30,37 @@ export default function UnverifiedProviders() {
   const t = useTranslations('pages.admin.unverified-providers');
 
   const [currentPage, setCurrentPage] = useState(0);
+  const [verifyingProviderId, setVerifyingProviderId] = useState<string | null>(
+    null,
+  );
 
   const { data: unverifiedProviders } = useGetUnverifiedProvidersQuery(
     currentPage,
     PAGE_SIZE,
   );
 
-  const { mutate: verifyProvider } = useVerifyProviderMutation();
+  const { mutate: verifyProvider, isPending } = useVerifyProviderMutation();
 
   const hasPreviousPage = currentPage > 0;
   const hasNextPage =
     unverifiedProviders &&
     currentPage < unverifiedProviders.page.totalPages - 1;
+
+  const verifyProviderHandler = (providerId: string) => {
+    setVerifyingProviderId(providerId);
+
+    verifyProvider(providerId, {
+      onSuccess: () => {
+        toast.success(t('messages.success'));
+      },
+      onError: () => {
+        toast.error(t('messages.error'));
+      },
+      onSettled: () => {
+        setVerifyingProviderId(null);
+      },
+    });
+  };
 
   return (
     <Card>
@@ -61,8 +81,14 @@ export default function UnverifiedProviders() {
 
                 <div>
                   <Button
+                    isPending={
+                      isPending && verifyingProviderId === provider.id
+                    }
+                    disabled={
+                      isPending && verifyingProviderId !== provider.id
+                    }
                     onClick={() => {
-                      verifyProvider(provider.id);
+                      verifyProviderHandler(provider.id);
                     }}
                   >
                     {t('actions.verify')}

--- a/apps/web/src/app/admin/_components/UnverifiedProviders.tsx
+++ b/apps/web/src/app/admin/_components/UnverifiedProviders.tsx
@@ -81,12 +81,8 @@ export default function UnverifiedProviders() {
 
                 <div>
                   <Button
-                    isPending={
-                      isPending && verifyingProviderId === provider.id
-                    }
-                    disabled={
-                      isPending && verifyingProviderId !== provider.id
-                    }
+                    isPending={isPending && verifyingProviderId === provider.id}
+                    disabled={isPending && verifyingProviderId !== provider.id}
                     onClick={() => {
                       verifyProviderHandler(provider.id);
                     }}

--- a/apps/web/src/features/provider/api/verify-provider.ts
+++ b/apps/web/src/features/provider/api/verify-provider.ts
@@ -1,70 +1,15 @@
-import { QueryClient, useMutation } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 
 import { server } from '@/lib/server';
-import { PagedResponse } from '@/types/server';
-
-type UnverifiedProvider = {
-  id: string;
-  name: string;
-};
-
-type UnverifiedProvidersPage = PagedResponse<UnverifiedProvider>;
 
 async function verifyProvider(id: string) {
   return server.patch<void>(`admin/providers/${id}/verify`);
 }
 
-function removeVerifiedProviderFromPage(
-  page: UnverifiedProvidersPage | undefined,
-  providerId: string,
-) {
-  if (!page) {
-    return page;
-  }
-
-  const content = page.content.filter((provider) => provider.id !== providerId);
-
-  if (content.length === page.content.length) {
-    return page;
-  }
-
-  const totalElements = Math.max(0, page.page.totalElements - 1);
-  const totalPages =
-    totalElements === 0 ? 0 : Math.ceil(totalElements / page.page.size);
-
-  return {
-    ...page,
-    content,
-    page: {
-      ...page.page,
-      totalElements,
-      totalPages,
-    },
-  };
-}
-
-function removeVerifiedProviderFromCache(
-  queryClient: QueryClient,
-  providerId: string,
-) {
-  const queries = queryClient.getQueriesData<UnverifiedProvidersPage>({
-    queryKey: ['unverified-providers'],
-  });
-
-  queries.forEach(([queryKey, page]) => {
-    queryClient.setQueryData(
-      queryKey,
-      removeVerifiedProviderFromPage(page, providerId),
-    );
-  });
-}
-
 export function useVerifyProviderMutation() {
   return useMutation({
     mutationFn: verifyProvider,
-    onSuccess: async (_data, providerId, _onMutateResult, context) => {
-      removeVerifiedProviderFromCache(context.client, providerId);
-
+    onSuccess: async (_data, _providerId, _onMutateResult, context) => {
       await context.client.invalidateQueries({
         queryKey: ['unverified-providers'],
       });

--- a/apps/web/src/features/provider/api/verify-provider.ts
+++ b/apps/web/src/features/provider/api/verify-provider.ts
@@ -1,13 +1,73 @@
-import { useMutation } from '@tanstack/react-query';
+import { QueryClient, useMutation } from '@tanstack/react-query';
 
 import { server } from '@/lib/server';
+import { PagedResponse } from '@/types/server';
+
+type UnverifiedProvider = {
+  id: string;
+  name: string;
+};
+
+type UnverifiedProvidersPage = PagedResponse<UnverifiedProvider>;
 
 async function verifyProvider(id: string) {
   return server.patch<void>(`admin/providers/${id}/verify`);
 }
 
+function removeVerifiedProviderFromPage(
+  page: UnverifiedProvidersPage | undefined,
+  providerId: string,
+) {
+  if (!page) {
+    return page;
+  }
+
+  const content = page.content.filter((provider) => provider.id !== providerId);
+
+  if (content.length === page.content.length) {
+    return page;
+  }
+
+  const totalElements = Math.max(0, page.page.totalElements - 1);
+  const totalPages =
+    totalElements === 0 ? 0 : Math.ceil(totalElements / page.page.size);
+
+  return {
+    ...page,
+    content,
+    page: {
+      ...page.page,
+      totalElements,
+      totalPages,
+    },
+  };
+}
+
+function removeVerifiedProviderFromCache(
+  queryClient: QueryClient,
+  providerId: string,
+) {
+  const queries = queryClient.getQueriesData<UnverifiedProvidersPage>({
+    queryKey: ['unverified-providers'],
+  });
+
+  queries.forEach(([queryKey, page]) => {
+    queryClient.setQueryData(
+      queryKey,
+      removeVerifiedProviderFromPage(page, providerId),
+    );
+  });
+}
+
 export function useVerifyProviderMutation() {
   return useMutation({
     mutationFn: verifyProvider,
+    onSuccess: async (_data, providerId, _onMutateResult, context) => {
+      removeVerifiedProviderFromCache(context.client, providerId);
+
+      await context.client.invalidateQueries({
+        queryKey: ['unverified-providers'],
+      });
+    },
   });
 }


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 버그 수정 / 리팩토링
- Related Issue: Closes

admin 계정으로 provider 검증 시, 하단에 결과 (성공/실패)토스트 띄우고 완료 시 리스트에서 해당 provider 제거 후 재조회하게 했습니다.

## PR Checklist

- [ ] 코드가 정상적으로 빌드되었나요?
- [ ] 적절한 테스트 코드가 추가되었나요? 추가되었다면 아래에 어떤 테스트인지 설명해 주세요.
  - [ ] 테스트 코드 설명
- [ ] 리뷰어 설정이 완료되었나요?

## Other

### 참고사항


### Screenshots / Videos (Optional)

<img width="1901" height="902" alt="image" src="https://github.com/user-attachments/assets/9d7076bc-2f0f-4c46-88d3-3a3a7f0fc3da" />


