### PR TITLE
feat: 사용자 프로필에 해당 사용자가 작성한 post를 보여주는 기능 추가

### DIFF
--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
         with:
-          version: "latest"
+          version: "10.33.0"
       - uses: actions/setup-node@v6
         with:
           node-version: "20"

--- a/apps/server/src/main/java/com/skkil/sync/reflection/repository/ReflectionQueryRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/reflection/repository/ReflectionQueryRepository.java
@@ -24,14 +24,14 @@ public class ReflectionQueryRepository {
 
   public Optional<ReflectionDto> getReflectionBySlug(String slug) {
     return dsl.select(
-            REFLECTIONS.ID,
-            REFLECTIONS.AUTHOR_ID,
-            USERS.FULL_NAME,
-            REFLECTIONS.CONTENT,
-            PROVIDERS.ID,
-            PROVIDERS.NAME,
-            REFLECTIONS.CREATED_AT,
-            REFLECTIONS.UPDATED_AT,
+            REFLECTIONS.ID.as("id"),
+            REFLECTIONS.AUTHOR_ID.as("authorId"),
+            USERS.FULL_NAME.as("authorName"),
+            REFLECTIONS.CONTENT.as("content"),
+            PROVIDERS.ID.as("projectId"),
+            PROVIDERS.NAME.as("projectName"),
+            REFLECTIONS.CREATED_AT.as("createdAt"),
+            REFLECTIONS.UPDATED_AT.as("updatedAt"),
             DSL.value(0L).as("likeCount"),
             DSL.value(0L).as("commentCount"))
         .from(REFLECTIONS)
@@ -51,14 +51,16 @@ public class ReflectionQueryRepository {
   public CursorPaginationDataFetcher<ReflectionDto> getReflections() {
     return (condition, orderFields, size) ->
         dsl.select(
-                REFLECTIONS.ID,
-                REFLECTIONS.AUTHOR_ID,
-                USERS.FULL_NAME,
-                REFLECTIONS.CONTENT,
-                PROVIDERS.ID,
-                PROVIDERS.NAME,
-                REFLECTIONS.CREATED_AT,
-                REFLECTIONS.UPDATED_AT)
+                REFLECTIONS.ID.as("id"),
+                REFLECTIONS.AUTHOR_ID.as("authorId"),
+                USERS.FULL_NAME.as("authorName"),
+                REFLECTIONS.CONTENT.as("content"),
+                PROVIDERS.ID.as("projectId"),
+                PROVIDERS.NAME.as("projectName"),
+                REFLECTIONS.CREATED_AT.as("createdAt"),
+                REFLECTIONS.UPDATED_AT.as("updatedAt"),
+                DSL.value(0L).as("likeCount"),
+                DSL.value(0L).as("commentCount"))
             .from(REFLECTIONS)
             .join(USERS)
             .on(REFLECTIONS.AUTHOR_ID.eq(USERS.ID))

--- a/apps/web/src/app/(app)/profile/[handle]/_components/ProfilePosts.tsx
+++ b/apps/web/src/app/(app)/profile/[handle]/_components/ProfilePosts.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useIntersectionObserver } from '@uidotdev/usehooks';
+import { useTranslations } from 'next-intl';
+import { useEffect } from 'react';
+
+import { useGetProfileByHandle } from '@/api/__generated__/profile/profile';
+import { useGetUserReflectionsInfinite } from '@/api/__generated__/reflection/reflection';
+import type { GetReflectionsResponseReflectionsNodesItemContent } from '@/api/__generated__/types';
+import { Badge } from '@/components/ui/badge';
+import { BaseViewer } from '@/components/ui/editor';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Spinner } from '@/components/ui/spinner';
+
+const POSTS_PAGE_SIZE = '10';
+
+interface ProfilePostsProps {
+  handle: string;
+}
+
+export default function ProfilePosts({ handle }: ProfilePostsProps) {
+  const t = useTranslations('pages.profile.posts');
+
+  const {
+    data: profile,
+    isPending: isProfilePending,
+    isError: isProfileError,
+  } = useGetProfileByHandle(handle);
+
+  const userId = profile?.data.userId;
+
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isPending: isPostsPending,
+    isError: isPostsError,
+  } = useGetUserReflectionsInfinite(
+    userId ?? '',
+    {
+      first: POSTS_PAGE_SIZE,
+      after: '',
+    },
+    {
+      query: {
+        enabled: !!userId,
+        getNextPageParam: (lastPage) => {
+          const pageInfo = lastPage.data.reflections?.pageInfo;
+          return pageInfo?.hasNextPage
+            ? (pageInfo.endCursor ?? undefined)
+            : undefined;
+        },
+      },
+    },
+  );
+
+  const [ref, entry] = useIntersectionObserver({
+    threshold: 0.2,
+    root: null,
+    rootMargin: '400px',
+  });
+
+  useEffect(() => {
+    if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [entry?.isIntersecting, fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  const posts =
+    data?.pages.flatMap((page) => page.data.reflections?.nodes ?? []) ?? [];
+
+  const isPending = isProfilePending || (!!userId && isPostsPending);
+  const isError = isProfileError || isPostsError;
+
+  return (
+    <section className="space-y-3">
+      <h2 className="text-base font-medium">{t('label')}</h2>
+
+      {isPending && <ProfilePostsSkeleton />}
+
+      {!isPending && isError && (
+        <div className="rounded-md border px-4 py-8 text-center">
+          <p className="text-sm text-destructive">{t('list.error')}</p>
+        </div>
+      )}
+
+      {!isPending && !isError && posts.length === 0 && (
+        <div className="rounded-md border px-4 py-8 text-center">
+          <p className="text-sm text-muted-foreground">{t('list.empty')}</p>
+        </div>
+      )}
+
+      {!isPending && !isError && posts.length > 0 && (
+        <>
+          <div className="space-y-4">
+            {posts.map((post) => (
+              <PostCard key={post.content.id} post={post.content} />
+            ))}
+          </div>
+
+          <div ref={ref} className="py-4">
+            {isFetchingNextPage && (
+              <div className="flex justify-center">
+                <Spinner />
+              </div>
+            )}
+          </div>
+
+          {!hasNextPage && (
+            <div className="py-4 text-center">
+              <p className="text-xs text-muted-foreground">{t('list.end')}</p>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+function PostCard({
+  post,
+}: {
+  post: GetReflectionsResponseReflectionsNodesItemContent;
+}) {
+  return (
+    <article className="rounded-md border p-4">
+      <div className="mb-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+        <span>{new Date(post.createdAt).toLocaleDateString()}</span>
+        {post.project?.name && (
+          <>
+            <span>|</span>
+            <Badge variant="secondary">{post.project.name}</Badge>
+          </>
+        )}
+      </div>
+
+      <BaseViewer content={post.content} />
+    </article>
+  );
+}
+
+function ProfilePostsSkeleton() {
+  return (
+    <div className="space-y-4">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <Skeleton key={index} className="h-32 w-full" />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/profile/[handle]/page.tsx
+++ b/apps/web/src/app/(app)/profile/[handle]/page.tsx
@@ -4,6 +4,7 @@ import { getGetProfileByHandleQueryOptions } from '@/api/__generated__/profile/p
 import { getQueryClient } from '@/lib/query';
 
 import ProfileCard from './_components/ProfileCard';
+import ProfilePosts from './_components/ProfilePosts';
 import Streaks from './_components/Streaks';
 
 interface ProfileProps {
@@ -23,6 +24,7 @@ export default async function Profile({ params }: ProfileProps) {
       <div className="space-y-4">
         <ProfileCard handle={handle} />
         <Streaks handle={handle} />
+        <ProfilePosts handle={handle} />
       </div>
     </HydrationBoundary>
   );


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 신규 기능 
- Related Issue: Closes #157 

사용자 프로필에서 해당 사용자가 작성한 post를 볼 수 있는 기능을 추가했습니다.
post의 좋아요 수, 댓글 수를 볼 수 있는 기능은 pr #156 에서 리뷰중인 사항이라서,
일단 post만 볼 수 있게 구현을 했습니다.

 ### Backend
  - 프로필 게시글 목록에서 사용하는 `/users/{userId}/reflections` 응답이 `ReflectionDto` 필드명과 안정적으로 매핑되도록
  jOOQ select 컬럼에 alias를 추가했습니다.
  - 목록 응답 타입에 포함된 `likeCount`, `commentCount` 값을 채우기 위해 임시 기본값 `0`을 함께 select하도록 수정했습니다.

### Screenshots / Videos (Optional)
<img width="2880" height="1462" alt="image" src="https://github.com/user-attachments/assets/e1bab805-8d37-45ac-afc9-e2e775507b5d" />
<img width="2880" height="1446" alt="image" src="https://github.com/user-attachments/assets/7b9c6090-27f4-41cf-8199-79617eaf2a37" />

