### PR TITLE
feat: 더 긴 포스트 작성을 위한 에디터 페이지 추가

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.1.0",
+    "@floating-ui/react": "^0.27.19",
     "@hookform/resolvers": "^5.2.2",
     "@phosphor-icons/react": "^2.1.10",
     "@stomp/stompjs": "^7.2.1",
@@ -24,6 +25,7 @@
     "@tiptap/pm": "^3.20.4",
     "@tiptap/react": "^3.20.4",
     "@tiptap/starter-kit": "^3.20.4",
+    "@tiptap/suggestion": "^3.23.6",
     "@uidotdev/usehooks": "^2.4.1",
     "better-auth": "^1.4.17",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,7 +25,7 @@
     "@tiptap/pm": "^3.20.4",
     "@tiptap/react": "^3.20.4",
     "@tiptap/starter-kit": "^3.20.4",
-    "@tiptap/suggestion": "^3.23.6",
+    "@tiptap/suggestion": "^3.20.4",
     "@uidotdev/usehooks": "^2.4.1",
     "better-auth": "^1.4.17",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         specifier: ^3.20.4
         version: 3.22.4
       '@tiptap/suggestion':
-        specifier: ^3.23.6
+        specifier: ^3.20.4
         version: 3.23.6(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)
       '@uidotdev/usehooks':
         specifier: ^2.4.1

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.1.0
         version: 1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@floating-ui/react':
+        specifier: ^0.27.19
+        version: 0.27.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.74.0(react@19.2.3))
@@ -40,6 +43,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^3.20.4
         version: 3.22.4
+      '@tiptap/suggestion':
+        specifier: ^3.23.6
+        version: 3.23.6(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)
       '@uidotdev/usehooks':
         specifier: ^2.4.1
         version: 2.4.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -976,6 +982,15 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  '@floating-ui/react@0.27.19':
+    resolution:
+      {
+        integrity: sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==,
+      }
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
 
   '@floating-ui/utils@0.2.11':
     resolution:
@@ -3788,6 +3803,15 @@ packages:
       {
         integrity: sha512-qWjw+vfdin1rzMRpRU4cC5tLTwMJtUpXeQukv+6mOqqvhptuwuZBjUHImVEJaSPoHXS7+1ut+nTnrLyWyEuE5Q==,
       }
+
+  '@tiptap/suggestion@3.23.6':
+    resolution:
+      {
+        integrity: sha512-YAoI2jctPClcyUhIcpxb1QlrUFG2a1Xsv1gS4tIfgh5KoOuEfGfCoeCq89TKgz/rHeP+ktRhzg1E2E4EY68HEA==,
+      }
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+      '@tiptap/pm': 3.23.6
 
   '@trivago/prettier-plugin-sort-imports@6.0.2':
     resolution:
@@ -8658,6 +8682,12 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
+  tabbable@6.4.0:
+    resolution:
+      {
+        integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==,
+      }
+
   tagged-tag@1.0.0:
     resolution:
       {
@@ -9910,6 +9940,14 @@ snapshots:
       '@floating-ui/dom': 1.7.6
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+
+  '@floating-ui/react@0.27.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.11': {}
 
@@ -11791,6 +11829,11 @@ snapshots:
       '@tiptap/extension-text': 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))
       '@tiptap/extension-underline': 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))
       '@tiptap/extensions': 3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)
+      '@tiptap/pm': 3.22.4
+
+  '@tiptap/suggestion@3.23.6(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4)':
+    dependencies:
+      '@tiptap/core': 3.22.4(@tiptap/pm@3.22.4)
       '@tiptap/pm': 3.22.4
 
   '@trivago/prettier-plugin-sort-imports@6.0.2(prettier@3.8.3)':
@@ -14996,6 +15039,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  tabbable@6.4.0: {}
 
   tagged-tag@1.0.0: {}
 

--- a/apps/web/public/locales/ko.json
+++ b/apps/web/public/locales/ko.json
@@ -4,6 +4,7 @@
       "post-editor": {
         "placeholder": "오늘은 무엇을 배우셨나요?",
         "post": {
+          "advanced": "더 자세히 작성하기",
           "label": "게시물 작성"
         }
       }
@@ -923,6 +924,32 @@
       "privacy": "개인정보 처리방침"
     },
     "editor": {
+      "commands": {
+        "h1": {
+          "title": "제목 1",
+          "description": ""
+        },
+        "h2": {
+          "title": "제목 2",
+          "description": ""
+        },
+        "bold": {
+          "title": "굵게",
+          "description": ""
+        },
+        "italic": {
+          "title": "기울임",
+          "description": ""
+        },
+        "ignore": {
+          "title": "/ 를 입력하기"
+        }
+      },
+      "placeholders": {
+        "title": "제목을 입력하세요",
+        "content": "/ 를 입력하여 명령어를 사용하거나 텍스트를 입력하세요"
+      },
+      "submit": "게시하기",
       "toolbar": {
         "bold": {
           "tooltip": "굵기 적용"

--- a/apps/web/src/app/(app)/(home)/_components/MiniPostEditor.tsx
+++ b/apps/web/src/app/(app)/(home)/_components/MiniPostEditor.tsx
@@ -389,9 +389,9 @@ export default function MiniPostEditor() {
                 />
               </div>
               <div className="flex items-center gap-3">
-                <Link href="/posts/new">
-                  <Button>{t('post.advanced')}</Button>
-                </Link>
+                <Button asChild>
+                  <Link href="/posts/new">{t('post.advanced')}</Link>
+                </Button>
 
                 <Button
                   disabled={isPostDisabled}

--- a/apps/web/src/app/(app)/(home)/_components/MiniPostEditor.tsx
+++ b/apps/web/src/app/(app)/(home)/_components/MiniPostEditor.tsx
@@ -6,6 +6,7 @@ import { EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { useTranslations } from 'next-intl';
 import NextImage from 'next/image';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { type ChangeEvent, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
@@ -387,8 +388,11 @@ export default function MiniPostEditor() {
                   onChange={handleImageChange}
                 />
               </div>
-
               <div className="flex items-center gap-3">
+                <Link href="/posts/new">
+                  <Button>{t('post.advanced')}</Button>
+                </Link>
+
                 <Button
                   disabled={isPostDisabled}
                   isPending={isCreatingPost || isUploadingImages}

--- a/apps/web/src/app/(app)/posts/new/_components/Editor.tsx
+++ b/apps/web/src/app/(app)/posts/new/_components/Editor.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import {
+  CodeIcon,
+  TextBolderIcon,
+  TextHOneIcon,
+  TextHTwoIcon,
+  TextItalicIcon,
+  TextStrikethroughIcon,
+} from '@phosphor-icons/react';
+import { CharacterCount, Placeholder } from '@tiptap/extensions';
+import { EditorContent, useEditor } from '@tiptap/react';
+import { BubbleMenu } from '@tiptap/react/menus';
+import StarterKit from '@tiptap/starter-kit';
+import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import { useCreateReflection } from '@/api/__generated__/reflection/reflection';
+import { Button } from '@/components/ui/button';
+import { CommandsExtension } from '@/components/ui/editor/extensions/commands';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
+
+export default function Editor() {
+  const t = useTranslations('components.editor');
+  const router = useRouter();
+
+  const { mutate: createPost } = useCreateReflection();
+
+  const [title, setTitle] = useState('');
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit,
+      Placeholder.configure({
+        placeholder: t('placeholders.content'),
+      }),
+      CharacterCount,
+      CommandsExtension,
+    ],
+    content: '',
+    immediatelyRender: false,
+  });
+
+  const handleSubmit = () => {
+    if (!editor) {
+      return;
+    }
+
+    createPost(
+      {
+        data: {
+          title,
+          content: {
+            json: JSON.stringify(editor.getJSON()),
+            text: editor.getText(),
+          },
+        },
+      },
+      {
+        onSuccess: ({ data: { slug } }) => {
+          router.push(`/posts/${slug}`);
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto py-12 flex flex-col gap-4">
+        <input
+          className="w-full shrink-0 resize-none bg-transparent text-4xl font-bold outline-none placeholder:text-muted-foreground leading-tight"
+          placeholder={t('placeholders.title')}
+          value={title}
+          onChange={(e) => {
+            setTitle(e.target.value);
+          }}
+        />
+
+        <ScrollArea className="flex-1 min-h-0 max-h-screen">
+          <EditorContent editor={editor} />
+          {editor && <EditorBubbleMenu editor={editor} />}
+        </ScrollArea>
+      </div>
+
+      <Separator />
+
+      <div className="px-6 py-3 flex items-center gap-4 shrink-0">
+        <div className="flex justify-end w-full">
+          <Button onClick={handleSubmit}>{t('submit')}</Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EditorBubbleMenu({
+  editor,
+}: {
+  editor: ReturnType<typeof useEditor>;
+}) {
+  const buttons = [
+    {
+      id: 'bold',
+      icon: <TextBolderIcon />,
+      isActive: () => editor?.isActive('bold') ?? false,
+      onClick: () => editor?.chain().focus().toggleBold().run(),
+    },
+    {
+      id: 'italic',
+      icon: <TextItalicIcon />,
+      isActive: () => editor?.isActive('italic') ?? false,
+      onClick: () => editor?.chain().focus().toggleItalic().run(),
+    },
+    {
+      id: 'strike',
+      icon: <TextStrikethroughIcon />,
+      isActive: () => editor?.isActive('strike') ?? false,
+      onClick: () => editor?.chain().focus().toggleStrike().run(),
+    },
+    {
+      id: 'code',
+      icon: <CodeIcon />,
+      isActive: () => editor?.isActive('code') ?? false,
+      onClick: () => editor?.chain().focus().toggleCode().run(),
+    },
+    null,
+    {
+      id: 'h1',
+      icon: <TextHOneIcon />,
+      isActive: () => editor?.isActive('heading', { level: 1 }) ?? false,
+      onClick: () => editor?.chain().focus().toggleHeading({ level: 1 }).run(),
+    },
+    {
+      id: 'h2',
+      icon: <TextHTwoIcon />,
+      isActive: () => editor?.isActive('heading', { level: 2 }) ?? false,
+      onClick: () => editor?.chain().focus().toggleHeading({ level: 2 }).run(),
+    },
+  ];
+
+  return (
+    <BubbleMenu
+      editor={editor}
+      className="flex items-center gap-0.5 rounded-lg border bg-popover p-1 shadow-lg"
+    >
+      {buttons.map((btn, i) =>
+        btn === null ? (
+          <Separator key={i} orientation="vertical" className="mx-1 h-5" />
+        ) : (
+          <button
+            key={btn.id}
+            type="button"
+            onClick={btn.onClick}
+            className={cn(
+              'rounded p-1.5 transition-colors hover:bg-accent',
+              btn.isActive() && 'bg-accent text-accent-foreground',
+            )}
+          >
+            {btn.icon}
+          </button>
+        ),
+      )}
+    </BubbleMenu>
+  );
+}

--- a/apps/web/src/app/(app)/posts/new/_components/Editor.tsx
+++ b/apps/web/src/app/(app)/posts/new/_components/Editor.tsx
@@ -158,6 +158,7 @@ function EditorBubbleMenu({
               'rounded p-1.5 transition-colors hover:bg-accent',
               btn.isActive() && 'bg-accent text-accent-foreground',
             )}
+            aria-label={btn.id}
           >
             {btn.icon}
           </button>

--- a/apps/web/src/app/(app)/posts/new/page.tsx
+++ b/apps/web/src/app/(app)/posts/new/page.tsx
@@ -1,0 +1,26 @@
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+import { auth, isAuthenticated, isOnboarded } from '@/lib/auth';
+
+import Editor from './_components/Editor';
+
+export default async function PostEditor() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (isAuthenticated(session) && !isOnboarded(session)) {
+    redirect('/onboarding');
+  }
+
+  if (!isAuthenticated(session)) {
+    redirect('/auth/login');
+  }
+
+  return (
+    <div className="h-full">
+      <Editor />
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/app.tsx
+++ b/apps/web/src/components/layout/app.tsx
@@ -8,18 +8,16 @@ interface AppLayoutProps {
 
 export function BaseLayout({ left, right, children }: AppLayoutProps) {
   return (
-    <>
+    <div className="min-h-screen flex flex-col">
       <div>
         <TopNavigationBar />
       </div>
 
-      <div className="pb-16 lg:pb-0">
-        <div className="flex max-w-7xl px-4 mx-auto gap-5">
-          <div className="hidden lg:block w-1/5">{left}</div>
-          <div className="grow">{children}</div>
-          <div className="hidden lg:block w-1/5">{right}</div>
-        </div>
+      <div className="grow flex pb-16 lg:pb-0 px-4 flex gap-5">
+        <div className="hidden lg:block w-1/5">{left}</div>
+        <div className="grow">{children}</div>
+        <div className="hidden lg:block w-1/5">{right}</div>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/web/src/components/ui/editor/extensions/commands.tsx
+++ b/apps/web/src/components/ui/editor/extensions/commands.tsx
@@ -19,6 +19,8 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
 
+const MAX_COMMAND_QUERY_LENGTH = 6;
+
 interface CommandsItemProps {
   name: string;
   icon: React.ReactNode;
@@ -99,10 +101,12 @@ export const CommandsExtension = Extension.create<CommandsExtensionOptions>({
         startOfLine: false,
         allow: ({ editor }) => editor.isFocused,
         render: () => {
-          let renderer: ReactRenderer<
-            CommandsRef,
-            CommandsProps & RefAttributes<CommandsRef>
-          > | void;
+          let renderer:
+            | ReactRenderer<
+                CommandsRef,
+                CommandsProps & RefAttributes<CommandsRef>
+              >
+            | undefined;
 
           return {
             onStart(props) {
@@ -124,9 +128,13 @@ export const CommandsExtension = Extension.create<CommandsExtensionOptions>({
                 return;
               }
 
-              if (props.query.length >= 6 || props.items.length === 0) {
+              if (
+                props.query.length >= MAX_COMMAND_QUERY_LENGTH ||
+                props.items.length === 0
+              ) {
                 renderer.element.remove();
                 renderer.destroy();
+                renderer = undefined;
                 return;
               }
 
@@ -143,6 +151,7 @@ export const CommandsExtension = Extension.create<CommandsExtensionOptions>({
                 if (renderer) {
                   renderer.element.remove();
                   renderer.destroy();
+                  renderer = undefined;
                 }
 
                 return true;
@@ -214,14 +223,20 @@ const Commands = forwardRef<CommandsRef, CommandsProps>((props, ref) => {
   useImperativeHandle(ref, () => ({
     onKeyDown: ({ event }) => {
       if (event.key === 'ArrowUp') {
-        setSelectedIndex(
-          (selectedIndex + props.items.length - 1) % props.items.length,
-        );
+        if (props.items.length !== 0) {
+          setSelectedIndex(
+            (prev) => (prev + props.items.length - 1) % props.items.length,
+          );
+        }
+
         return true;
       }
 
       if (event.key === 'ArrowDown') {
-        setSelectedIndex((selectedIndex + 1) % props.items.length);
+        if (props.items.length !== 0) {
+          setSelectedIndex((prev) => (prev + 1) % props.items.length);
+        }
+
         return true;
       }
 
@@ -239,6 +254,7 @@ const Commands = forwardRef<CommandsRef, CommandsProps>((props, ref) => {
       {props.items.map((item, index) => (
         <div
           key={index}
+          role="button"
           className={cn(
             'flex cursor-pointer items-center rounded-md',
             index === selectedIndex

--- a/apps/web/src/components/ui/editor/extensions/commands.tsx
+++ b/apps/web/src/components/ui/editor/extensions/commands.tsx
@@ -1,0 +1,270 @@
+import { computePosition, flip, shift } from '@floating-ui/react';
+import { TextBIcon, TextHTwoIcon, TextItalicIcon } from '@phosphor-icons/react';
+import { TextHOneIcon } from '@phosphor-icons/react/dist/ssr';
+import { Extension, ReactRenderer, posToDOMRect } from '@tiptap/react';
+import type { Editor, Range } from '@tiptap/react';
+import {
+  Suggestion,
+  type SuggestionOptions,
+  type SuggestionProps,
+} from '@tiptap/suggestion';
+import { useTranslations } from 'next-intl';
+import {
+  type RefAttributes,
+  forwardRef,
+  useImperativeHandle,
+  useState,
+} from 'react';
+
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
+
+interface CommandsItemProps {
+  name: string;
+  icon: React.ReactNode;
+  command: (props: { editor: Editor; range: Range }) => void;
+}
+
+interface CommandsExtensionOptions {
+  suggestion: Partial<SuggestionOptions<CommandsItemProps>>;
+}
+
+export const CommandsExtension = Extension.create<CommandsExtensionOptions>({
+  name: 'commands',
+  addOptions() {
+    return {
+      suggestion: {
+        char: '/',
+        command({ editor, range, props }) {
+          props.command({ editor, range });
+        },
+        items({ query }) {
+          return (
+            [
+              {
+                name: 'h1',
+                icon: <TextHOneIcon />,
+                command: ({ editor, range }) => {
+                  editor
+                    .chain()
+                    .focus()
+                    .deleteRange(range)
+                    .setNode('heading', { level: 1 })
+                    .run();
+                },
+              },
+              {
+                name: 'h2',
+                icon: <TextHTwoIcon />,
+                command: ({ editor, range }) => {
+                  editor
+                    .chain()
+                    .focus()
+                    .deleteRange(range)
+                    .setNode('heading', { level: 2 })
+                    .run();
+                },
+              },
+              {
+                name: 'bold',
+                icon: <TextBIcon />,
+                command: ({ editor, range }) => {
+                  editor
+                    .chain()
+                    .focus()
+                    .deleteRange(range)
+                    .setMark('bold')
+                    .run();
+                },
+              },
+              {
+                name: 'italic',
+                icon: <TextItalicIcon />,
+                command: ({ editor, range }) => {
+                  editor
+                    .chain()
+                    .focus()
+                    .deleteRange(range)
+                    .setMark('italic')
+                    .run();
+                },
+              },
+            ] satisfies CommandsItemProps[]
+          )
+            .filter((item) => {
+              return item.name.startsWith(query.toLowerCase());
+            })
+            .slice(0, 10);
+        },
+        startOfLine: false,
+        allow: ({ editor }) => editor.isFocused,
+        render: () => {
+          let renderer: ReactRenderer<
+            CommandsRef,
+            CommandsProps & RefAttributes<CommandsRef>
+          > | void;
+
+          return {
+            onStart(props) {
+              if (!props.clientRect) {
+                return;
+              }
+
+              renderer = new ReactRenderer(Commands, {
+                props,
+                editor: props.editor,
+              });
+
+              (renderer.element as HTMLElement).style.position = 'absolute';
+              document.body.appendChild(renderer.element);
+              updatePosition(props.editor, renderer.element as HTMLElement);
+            },
+            onUpdate(props) {
+              if (!renderer) {
+                return;
+              }
+
+              if (props.query.length >= 6 || props.items.length === 0) {
+                renderer.element.remove();
+                renderer.destroy();
+                return;
+              }
+
+              renderer.updateProps(props);
+
+              if (!props.clientRect) {
+                return;
+              }
+
+              updatePosition(props.editor, renderer.element as HTMLElement);
+            },
+            onKeyDown(props) {
+              if (props.event.key === 'Escape') {
+                if (renderer) {
+                  renderer.element.remove();
+                  renderer.destroy();
+                }
+
+                return true;
+              }
+
+              return renderer?.ref?.onKeyDown(props) ?? false;
+            },
+            onExit: () => {
+              if (renderer) {
+                renderer.element.remove();
+                renderer.destroy();
+              }
+            },
+          };
+        },
+      },
+    };
+  },
+  addProseMirrorPlugins() {
+    return [
+      Suggestion<CommandsItemProps>({
+        editor: this.editor,
+        ...this.options.suggestion,
+      }),
+    ];
+  },
+});
+
+function updatePosition(editor: Editor, element: HTMLElement) {
+  const velement = {
+    getBoundingClientRect: () =>
+      posToDOMRect(
+        editor.view,
+        editor.state.selection.from,
+        editor.state.selection.to,
+      ),
+  };
+
+  computePosition(velement, element, {
+    placement: 'bottom-start',
+    strategy: 'absolute',
+    middleware: [shift(), flip()],
+  }).then(({ x, y, strategy }) => {
+    element.style.width = 'max-content';
+    element.style.position = strategy;
+    element.style.left = `${x}px`;
+    element.style.top = `${y}px`;
+  });
+}
+
+interface CommandsRef {
+  onKeyDown: (props: { event: KeyboardEvent }) => boolean;
+}
+
+type CommandsProps = SuggestionProps<CommandsItemProps>;
+
+const Commands = forwardRef<CommandsRef, CommandsProps>((props, ref) => {
+  const t = useTranslations('components.editor.commands');
+
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const selectItem = (index: number) => {
+    const item = props.items[index];
+    if (item) {
+      props.command(item);
+    }
+  };
+
+  useImperativeHandle(ref, () => ({
+    onKeyDown: ({ event }) => {
+      if (event.key === 'ArrowUp') {
+        setSelectedIndex(
+          (selectedIndex + props.items.length - 1) % props.items.length,
+        );
+        return true;
+      }
+
+      if (event.key === 'ArrowDown') {
+        setSelectedIndex((selectedIndex + 1) % props.items.length);
+        return true;
+      }
+
+      if (event.key === 'Enter') {
+        selectItem(selectedIndex);
+        return true;
+      }
+
+      return false;
+    },
+  }));
+
+  return (
+    <div className="w-64 rounded-lg border bg-popover p-1 shadow-lg">
+      {props.items.map((item, index) => (
+        <div
+          key={index}
+          className={cn(
+            'flex cursor-pointer items-center rounded-md',
+            index === selectedIndex
+              ? 'bg-primary text-primary-foreground'
+              : 'hover:bg-accent',
+          )}
+          onClick={() => selectItem(index)}
+        >
+          <div className="flex items-center justify-center p-2">
+            {item.icon}
+          </div>
+
+          <div className="flex flex-col">
+            <span className="text-sm">{t(`${item.name}.title`)}</span>
+            <span className="text-xs">{t(`${item.name}.description`)}</span>
+          </div>
+        </div>
+      ))}
+
+      <Separator />
+
+      <div className="flex items-center justify-between px-3 py-2">
+        <span className="text-sm">{t('ignore.title')}</span>
+        <span className="text-xs">ESC</span>
+      </div>
+    </div>
+  );
+});
+Commands.displayName = 'Commands';


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 신규 기능
- Related Issue: 

더 긴 포스트 작성을 위해 홈 페이지에 있던 mini post editor에서 전용 에디터로 넘어갈 수 있도록 구현했습니다.
에디터는 노션 따라하려고 했고, 텍스트만 일단 작성할 수 있도록 했습니다.

## PR Checklist

- [x] 코드가 정상적으로 빌드되었나요?
- [ ] 적절한 테스트 코드가 추가되었나요? 추가되었다면 아래에 어떤 테스트인지 설명해 주세요.
- [x] 리뷰어 설정이 완료되었나요?