### PR TITLE
뱃지, 도감 기본 기능 개발

### DIFF
--- a/apps/server/src/main/java/com/skkil/sync/badge/controller/BadgeCollectionController.java
+++ b/apps/server/src/main/java/com/skkil/sync/badge/controller/BadgeCollectionController.java
@@ -1,0 +1,28 @@
+package com.skkil.sync.badge.controller;
+
+import com.skkil.sync.auth.AuthenticatedUser;
+import com.skkil.sync.badge.dto.response.GetBadgeCollectionsResponse;
+import com.skkil.sync.badge.service.BadgeCollectionQueryService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class BadgeCollectionController {
+
+  private final BadgeCollectionQueryService badgeCollectionQueryService;
+
+  public BadgeCollectionController(BadgeCollectionQueryService badgeCollectionQueryService) {
+    this.badgeCollectionQueryService = badgeCollectionQueryService;
+  }
+
+  @GetMapping("/users/{userId}/badges")
+  @ResponseStatus(HttpStatus.OK)
+  public GetBadgeCollectionsResponse getBadgeCollections(
+      @AuthenticationPrincipal AuthenticatedUser user, @PathVariable Long userId) {
+    return badgeCollectionQueryService.getBadgeCollections(user, userId);
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/badge/dto/response/GetBadgeCollectionsResponse.java
+++ b/apps/server/src/main/java/com/skkil/sync/badge/dto/response/GetBadgeCollectionsResponse.java
@@ -1,0 +1,14 @@
+package com.skkil.sync.badge.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+import lombok.Builder;
+
+public record GetBadgeCollectionsResponse(List<Badge> badges) {
+
+  @Builder
+  public static record Badge(Long id, Tag tag, Long postCount, Integer level, Instant createdAt) {}
+
+  @Builder
+  public static record Tag(Long id, String name, String description, String imageUrl) {}
+}

--- a/apps/server/src/main/java/com/skkil/sync/badge/model/BadgeCollection.java
+++ b/apps/server/src/main/java/com/skkil/sync/badge/model/BadgeCollection.java
@@ -1,0 +1,49 @@
+package com.skkil.sync.badge.model;
+
+import com.skkil.sync.common.domain.BaseEntity;
+import com.skkil.sync.reflection.model.Tag;
+import com.skkil.sync.user.model.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+
+@Entity
+@Table(
+    name = "badge_collections",
+    uniqueConstraints = {@UniqueConstraint(columnNames = {"user_id", "tag_id"})})
+@Getter
+public class BadgeCollection extends BaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "tag_id", nullable = false)
+  private Tag tag;
+
+  @Column(name = "user_post_count", nullable = false)
+  private Long postCount;
+
+  @Column(name = "level", nullable = false)
+  private Integer level;
+
+  protected BadgeCollection() {}
+
+  public BadgeCollection(User user, Tag tag, Long postCount, Integer level) {
+    this.user = user;
+    this.tag = tag;
+    this.postCount = postCount;
+    this.level = level;
+  }
+
+  public void updateProgress(Long postCount, Integer level) {
+    this.postCount = postCount;
+    this.level = level;
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/badge/repository/BadgeCollectionQueryRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/badge/repository/BadgeCollectionQueryRepository.java
@@ -1,0 +1,19 @@
+package com.skkil.sync.badge.repository;
+
+import com.skkil.sync.badge.model.BadgeCollection;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class BadgeCollectionQueryRepository {
+
+  private final BadgeCollectionRepository badgeCollectionRepository;
+
+  public BadgeCollectionQueryRepository(BadgeCollectionRepository badgeCollectionRepository) {
+    this.badgeCollectionRepository = badgeCollectionRepository;
+  }
+
+  public List<BadgeCollection> findAllByUserId(Long userId) {
+    return badgeCollectionRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/badge/repository/BadgeCollectionRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/badge/repository/BadgeCollectionRepository.java
@@ -1,0 +1,15 @@
+package com.skkil.sync.badge.repository;
+
+import com.skkil.sync.badge.model.BadgeCollection;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BadgeCollectionRepository extends JpaRepository<BadgeCollection, Long> {
+
+  Optional<BadgeCollection> findByUserIdAndTagId(Long userId, Long tagId);
+
+  @EntityGraph(attributePaths = {"tag"})
+  List<BadgeCollection> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/apps/server/src/main/java/com/skkil/sync/badge/service/BadgeCollectionQueryService.java
+++ b/apps/server/src/main/java/com/skkil/sync/badge/service/BadgeCollectionQueryService.java
@@ -1,0 +1,61 @@
+package com.skkil.sync.badge.service;
+
+import com.skkil.sync.auth.AuthenticatedUser;
+import com.skkil.sync.badge.dto.response.GetBadgeCollectionsResponse;
+import com.skkil.sync.badge.model.BadgeCollection;
+import com.skkil.sync.badge.repository.BadgeCollectionQueryRepository;
+import com.skkil.sync.user.exception.UserNotFoundException;
+import com.skkil.sync.user.model.User;
+import com.skkil.sync.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class BadgeCollectionQueryService {
+
+  private final BadgeCollectionQueryRepository badgeCollectionQueryRepository;
+  private final UserRepository userRepository;
+
+  public BadgeCollectionQueryService(
+      BadgeCollectionQueryRepository badgeCollectionQueryRepository,
+      UserRepository userRepository) {
+    this.badgeCollectionQueryRepository = badgeCollectionQueryRepository;
+    this.userRepository = userRepository;
+  }
+
+  @Transactional(readOnly = true)
+  public GetBadgeCollectionsResponse getBadgeCollections(AuthenticatedUser requester, Long userId) {
+    User user =
+        userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
+    Long requesterId = requester == null ? null : requester.userId();
+
+    if (!user.isEnabled() && !userId.equals(requesterId)) {
+      throw new UserNotFoundException(userId);
+    }
+
+    var badges =
+        badgeCollectionQueryRepository.findAllByUserId(userId).stream()
+            .map(this::toBadgeResponse)
+            .toList();
+
+    return new GetBadgeCollectionsResponse(badges);
+  }
+
+  private GetBadgeCollectionsResponse.Badge toBadgeResponse(BadgeCollection badgeCollection) {
+    var tag = badgeCollection.getTag();
+
+    return GetBadgeCollectionsResponse.Badge.builder()
+        .id(badgeCollection.getId())
+        .tag(
+            GetBadgeCollectionsResponse.Tag.builder()
+                .id(tag.getId())
+                .name(tag.getName())
+                .description(tag.getDescription())
+                .imageUrl(tag.getImageUrl())
+                .build())
+        .postCount(badgeCollection.getPostCount())
+        .level(badgeCollection.getLevel())
+        .createdAt(badgeCollection.getCreatedAt())
+        .build();
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/badge/service/BadgeCollectionService.java
+++ b/apps/server/src/main/java/com/skkil/sync/badge/service/BadgeCollectionService.java
@@ -1,0 +1,81 @@
+package com.skkil.sync.badge.service;
+
+import com.skkil.sync.badge.model.BadgeCollection;
+import com.skkil.sync.badge.repository.BadgeCollectionRepository;
+import com.skkil.sync.reflection.model.Tag;
+import com.skkil.sync.user.model.User;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class BadgeCollectionService {
+
+  private static final long LEVEL_4_POST_COUNT = 20L;
+  private static final long LEVEL_3_POST_COUNT = 10L;
+  private static final long LEVEL_2_POST_COUNT = 5L;
+  private static final long LEVEL_1_POST_COUNT = 1L;
+
+  private final BadgeCollectionRepository badgeCollectionRepository;
+
+  public BadgeCollectionService(BadgeCollectionRepository badgeCollectionRepository) {
+    this.badgeCollectionRepository = badgeCollectionRepository;
+  }
+
+  @Transactional
+  public void increaseBadges(User user, List<Tag> tags) {
+    for (Tag tag : tags) {
+      if (!tag.isVerified()) {
+        continue;
+      }
+
+      BadgeCollection badgeCollection =
+          badgeCollectionRepository
+              .findByUserIdAndTagId(user.getId(), tag.getId())
+              .orElseGet(() -> new BadgeCollection(user, tag, 0L, 0));
+
+      long postCount = badgeCollection.getPostCount() + 1;
+      badgeCollection.updateProgress(postCount, calculateLevel(postCount));
+      badgeCollectionRepository.save(badgeCollection);
+    }
+  }
+
+  @Transactional
+  public void decreaseBadges(User user, List<Tag> tags) {
+    for (Tag tag : tags) {
+      if (!tag.isVerified()) {
+        continue;
+      }
+
+      badgeCollectionRepository
+          .findByUserIdAndTagId(user.getId(), tag.getId())
+          .ifPresent(
+              badgeCollection -> {
+                long postCount = badgeCollection.getPostCount() - 1;
+                if (postCount <= 0) {
+                  badgeCollectionRepository.delete(badgeCollection);
+                  return;
+                }
+
+                badgeCollection.updateProgress(postCount, calculateLevel(postCount));
+              });
+    }
+  }
+
+  private int calculateLevel(long postCount) {
+    if (postCount >= LEVEL_4_POST_COUNT) {
+      return 4;
+    }
+    if (postCount >= LEVEL_3_POST_COUNT) {
+      return 3;
+    }
+    if (postCount >= LEVEL_2_POST_COUNT) {
+      return 2;
+    }
+    if (postCount >= LEVEL_1_POST_COUNT) {
+      return 1;
+    }
+
+    return 0;
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/reflection/model/Tag.java
+++ b/apps/server/src/main/java/com/skkil/sync/reflection/model/Tag.java
@@ -18,6 +18,9 @@ public class Tag extends BaseEntity {
   @Column(name = "description")
   private String description;
 
+  @Column(name = "image_url", length = 2048)
+  private String imageUrl;
+
   @Column(name = "post_count", nullable = false)
   private Long postCount;
 
@@ -31,5 +34,9 @@ public class Tag extends BaseEntity {
     this.name = name;
     this.description = "";
     this.postCount = 0L;
+  }
+
+  public void updateImageUrl(String imageUrl) {
+    this.imageUrl = imageUrl;
   }
 }

--- a/apps/server/src/main/java/com/skkil/sync/reflection/repository/ReflectionRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/reflection/repository/ReflectionRepository.java
@@ -11,6 +11,17 @@ public interface ReflectionRepository extends JpaRepository<Reflection, Long> {
 
   Optional<Reflection> findBySlug(String slug);
 
+  @Query(
+      """
+      SELECT r
+      FROM Reflection r
+      JOIN FETCH r.author
+      LEFT JOIN FETCH r.tags rt
+      LEFT JOIN FETCH rt.tag
+      WHERE r.id = :id
+      """)
+  Optional<Reflection> findByIdWithAuthorAndTags(Long id);
+
   @Modifying
   @Query(
       value =

--- a/apps/server/src/main/java/com/skkil/sync/reflection/service/ReflectionService.java
+++ b/apps/server/src/main/java/com/skkil/sync/reflection/service/ReflectionService.java
@@ -1,5 +1,6 @@
 package com.skkil.sync.reflection.service;
 
+import com.skkil.sync.badge.service.BadgeCollectionService;
 import com.skkil.sync.common.util.text.Slugify;
 import com.skkil.sync.experience.constant.ExperienceType;
 import com.skkil.sync.experience.model.Experience;
@@ -14,6 +15,7 @@ import com.skkil.sync.reflection.exception.ReflectionNotFoundException;
 import com.skkil.sync.reflection.model.Reflection;
 import com.skkil.sync.reflection.model.ReflectionMediaFile;
 import com.skkil.sync.reflection.model.ReflectionSummary;
+import com.skkil.sync.reflection.model.Tag;
 import com.skkil.sync.reflection.repository.ReflectionMediaFileRepository;
 import com.skkil.sync.reflection.repository.ReflectionRepository;
 import com.skkil.sync.reflection.repository.ReflectionSummaryRepository;
@@ -21,6 +23,7 @@ import com.skkil.sync.user.model.User;
 import com.skkil.sync.user.service.domain.UserDomainService;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.List;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -30,6 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReflectionService {
 
   private final UserDomainService userDomainService;
+  private final BadgeCollectionService badgeCollectionService;
   private final TagService tagService;
   private final ExperienceDomainService experienceDomainService;
   private final ReflectionContentMediaService contentMediaService;
@@ -41,6 +45,7 @@ public class ReflectionService {
 
   public ReflectionService(
       UserDomainService userDomainService,
+      BadgeCollectionService badgeCollectionService,
       TagService tagService,
       ExperienceDomainService experienceDomainService,
       ReflectionContentMediaService contentMediaService,
@@ -49,6 +54,7 @@ public class ReflectionService {
       ReflectionSummaryRepository reflectionSummaryRepository,
       ApplicationEventPublisher eventPublisher) {
     this.userDomainService = userDomainService;
+    this.badgeCollectionService = badgeCollectionService;
     this.tagService = tagService;
     this.experienceDomainService = experienceDomainService;
     this.contentMediaService = contentMediaService;
@@ -77,9 +83,10 @@ public class ReflectionService {
             .title(request.title())
             .content(preparedContent.content())
             .build();
-    tagService.addTagsToReflection(reflection, request.tags());
+    List<Tag> tags = tagService.addTagsToReflection(reflection, request.tags());
 
     reflection = reflectionRepository.save(reflection);
+    badgeCollectionService.increaseBadges(author, tags);
 
     for (int i = 0; i < preparedContent.mediaFiles().size(); i++) {
       reflectionMediaFileRepository.save(
@@ -140,6 +147,15 @@ public class ReflectionService {
       throw new ReflectionNotFoundException(reflectionId);
     }
 
-    reflectionRepository.deleteById(reflectionId);
+    Reflection reflection =
+        reflectionRepository
+            .findByIdWithAuthorAndTags(reflectionId)
+            .orElseThrow(() -> new ReflectionNotFoundException(reflectionId));
+
+    List<Tag> tags =
+        reflection.getTags().stream().map(reflectionTag -> reflectionTag.getTag()).toList();
+    tagService.decrementPostCounts(tags);
+    badgeCollectionService.decreaseBadges(reflection.getAuthor(), tags);
+    reflectionRepository.delete(reflection);
   }
 }

--- a/apps/server/src/main/java/com/skkil/sync/reflection/service/TagService.java
+++ b/apps/server/src/main/java/com/skkil/sync/reflection/service/TagService.java
@@ -7,6 +7,7 @@ import com.skkil.sync.reflection.model.Reflection;
 import com.skkil.sync.reflection.model.ReflectionTag;
 import com.skkil.sync.reflection.model.Tag;
 import com.skkil.sync.reflection.repository.TagRepository;
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,9 +38,9 @@ public class TagService {
   }
 
   @Transactional
-  public void addTagsToReflection(Reflection reflection, List<String> tags) {
+  public List<Tag> addTagsToReflection(Reflection reflection, List<String> tags) {
     if (tags == null || tags.isEmpty()) {
-      return;
+      return List.of();
     }
 
     List<String> filteredTags =
@@ -54,6 +55,7 @@ public class TagService {
       throw new ReflectionTagLimitExceededException();
     }
 
+    List<Tag> reflectionTags = new ArrayList<>();
     for (String name : filteredTags) {
       Tag tag =
           tagRepository
@@ -63,6 +65,16 @@ public class TagService {
       ReflectionTag reflectionTag = ReflectionTag.builder().reflection(reflection).tag(tag).build();
       reflection.addTag(reflectionTag);
       tagRepository.incrementPostCount(tag);
+      reflectionTags.add(tag);
+    }
+
+    return reflectionTags;
+  }
+
+  @Transactional
+  public void decrementPostCounts(List<Tag> tags) {
+    for (Tag tag : tags) {
+      tagRepository.decrementPostCount(tag);
     }
   }
 }

--- a/apps/server/src/main/resources/db/changelog/changesets/00025-create-table-badge-collections.yaml
+++ b/apps/server/src/main/resources/db/changelog/changesets/00025-create-table-badge-collections.yaml
@@ -1,0 +1,94 @@
+databaseChangeLog:
+  - changeSet:
+      id: 00025-add-image-url-to-tags
+      author: jieunseo
+      preConditions:
+        - and:
+            - tableExists:
+                tableName: tags
+            - not:
+                columnExists:
+                  tableName: tags
+                  columnName: image_url
+      changes:
+        - addColumn:
+            tableName: tags
+            columns:
+              - column:
+                  name: image_url
+                  type: VARCHAR(2048)
+
+  - changeSet:
+      id: 00025-create-table-badge-collections
+      author: jieunseo
+      preConditions:
+        - and:
+            - tableExists:
+                tableName: users
+            - tableExists:
+                tableName: tags
+            - not:
+                tableExists:
+                  tableName: badge_collections
+      changes:
+        - createTable:
+            tableName: badge_collections
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: tag_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: user_post_count
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: level
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: badge_collections
+            baseColumnNames: user_id
+            referencedTableName: users
+            referencedColumnNames: id
+            constraintName: fk_badge_collections_user_id
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            baseTableName: badge_collections
+            baseColumnNames: tag_id
+            referencedTableName: tags
+            referencedColumnNames: id
+            constraintName: fk_badge_collections_tag_id
+            onDelete: CASCADE
+        - addUniqueConstraint:
+            tableName: badge_collections
+            columnNames: user_id, tag_id
+            constraintName: uq_badge_collections_user_id_tag_id

--- a/apps/server/src/test/java/com/skkil/sync/badge/controller/BadgeCollectionControllerTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/badge/controller/BadgeCollectionControllerTests.java
@@ -1,0 +1,72 @@
+package com.skkil.sync.badge.controller;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.Schema.schema;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.skkil.sync.auth.AuthenticatedUser;
+import com.skkil.sync.badge.dto.response.GetBadgeCollectionsResponse;
+import com.skkil.sync.badge.service.BadgeCollectionQueryService;
+import com.skkil.sync.badge.snippets.GetBadgeCollectionsResponseSnippets;
+import com.skkil.sync.common.config.TestSecurityConfig;
+import com.skkil.sync.config.SecurityConfig;
+import java.util.function.Function;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restdocs.test.autoconfigure.AutoConfigureRestDocs;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(BadgeCollectionController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
+@ExtendWith(RestDocumentationExtension.class)
+@Import({SecurityConfig.class, TestSecurityConfig.class})
+class BadgeCollectionControllerTests {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private BadgeCollectionQueryService badgeCollectionQueryService;
+
+  @Test
+  @DisplayName("[getBadgeCollections] API 문서화 테스트")
+  void getBadgeCollections() throws Exception {
+    Long userId = 1L;
+    GetBadgeCollectionsResponse response =
+        GetBadgeCollectionsResponseSnippets.getGetBadgeCollectionsResponse();
+
+    when(badgeCollectionQueryService.getBadgeCollections(
+            isNull(AuthenticatedUser.class), eq(userId)))
+        .thenReturn(response);
+
+    mockMvc
+        .perform(get("/users/{userId}/badges", userId))
+        .andExpect(status().isOk())
+        .andDo(
+            document(
+                "GetBadgeCollections",
+                ResourceSnippetParameters.builder()
+                    .tag("badge")
+                    .summary("Get Badge Collections")
+                    .description("유저의 뱃지 도감을 조회합니다.")
+                    .responseSchema(schema(GetBadgeCollectionsResponse.class.getSimpleName())),
+                null,
+                null,
+                Function.identity(),
+                pathParameters(parameterWithName("userId").description("유저 ID")),
+                GetBadgeCollectionsResponseSnippets.getBadgeCollectionsResponseFields()));
+  }
+}

--- a/apps/server/src/test/java/com/skkil/sync/badge/snippets/GetBadgeCollectionsResponseSnippets.java
+++ b/apps/server/src/test/java/com/skkil/sync/badge/snippets/GetBadgeCollectionsResponseSnippets.java
@@ -1,0 +1,50 @@
+package com.skkil.sync.badge.snippets;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+import com.skkil.sync.badge.dto.response.GetBadgeCollectionsResponse;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+
+public class GetBadgeCollectionsResponseSnippets {
+
+  public static GetBadgeCollectionsResponse getGetBadgeCollectionsResponse() {
+    return new GetBadgeCollectionsResponse(
+        List.of(
+            GetBadgeCollectionsResponse.Badge.builder()
+                .id(1L)
+                .tag(
+                    GetBadgeCollectionsResponse.Tag.builder()
+                        .id(1L)
+                        .name("java")
+                        .description("자바 관련 태그")
+                        .imageUrl("https://example.com/badges/java.png")
+                        .build())
+                .postCount(10L)
+                .level(3)
+                .createdAt(Instant.parse("2026-05-27T10:00:00Z"))
+                .build()));
+  }
+
+  public static ResponseFieldsSnippet getBadgeCollectionsResponseFields() {
+    return responseFields(
+        fieldWithPath("badges").type(JsonFieldType.ARRAY).description("뱃지 도감 목록"),
+        fieldWithPath("badges[].id").type(JsonFieldType.NUMBER).description("도감 항목 ID"),
+        fieldWithPath("badges[].tag").type(JsonFieldType.OBJECT).description("뱃지 태그"),
+        fieldWithPath("badges[].tag.id").type(JsonFieldType.NUMBER).description("태그 ID"),
+        fieldWithPath("badges[].tag.name").type(JsonFieldType.STRING).description("태그 이름"),
+        fieldWithPath("badges[].tag.description").type(JsonFieldType.STRING).description("태그 설명"),
+        fieldWithPath("badges[].tag.imageUrl")
+            .type(JsonFieldType.STRING)
+            .description("뱃지 이미지 URL")
+            .optional(),
+        fieldWithPath("badges[].postCount")
+            .type(JsonFieldType.NUMBER)
+            .description("해당 태그로 작성한 글 수"),
+        fieldWithPath("badges[].level").type(JsonFieldType.NUMBER).description("뱃지 레벨"),
+        fieldWithPath("badges[].createdAt").type(JsonFieldType.STRING).description("뱃지 최초 획득 시각"));
+  }
+}

--- a/docs/api/openapi3.yaml
+++ b/docs/api/openapi3.yaml
@@ -287,6 +287,43 @@ paths:
                     \ reflection content\",\"likeCount\":10,\"commentCount\":5,\"\
                     bookmarked\":true,\"createdAt\":\"2026-05-04T12:00:00\",\"bookmarkedAt\"\
                     :\"2026-05-05T12:00:00\"}}]}}"
+  /comments:
+    get:
+      tags:
+      - comment
+      summary: Get Comments
+      description: Get Comments
+      operationId: GetComments
+      parameters:
+      - name: targetType
+        in: query
+        description: Comment target type
+        required: true
+        schema:
+          type: string
+      - name: targetId
+        in: query
+        description: Comment target ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetCommentsResponse"
+              examples:
+                GetComments:
+                  value: "{\"comments\":[{\"id\":1,\"author\":{\"id\":1,\"handle\"\
+                    :\"user-handle\"},\"content\":\"Comment content\",\"deleted\"\
+                    :false,\"likeCount\":1,\"createdAt\":\"2026-01-01T00:00:00Z\"\
+                    ,\"updatedAt\":\"2026-01-01T00:00:00Z\",\"replies\":[{\"id\":2,\"\
+                    author\":{\"id\":1,\"handle\":\"user-handle\"},\"content\":\"\
+                    Reply content\",\"deleted\":false,\"likeCount\":0,\"createdAt\"\
+                    :\"2026-01-01T00:00:00Z\",\"updatedAt\":\"2026-01-01T00:00:00Z\"\
+                    ,\"replies\":[]}]}]}"
   /comments/{commentId}:
     delete:
       tags:
@@ -696,6 +733,55 @@ paths:
                     Software Engineer\",\"jobDescription\":\"Job Description\",\"\
                     location\":\"Location\",\"createdAt\":\"1970-01-01T00:00:00\"\
                     ,\"updatedAt\":\"1970-01-01T00:00:00\"}]}}"
+  /likes:
+    post:
+      tags:
+      - like
+      summary: Create Like
+      description: Create Like
+      operationId: CreateLike
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateLikeRequest"
+            examples:
+              CreateLike:
+                value: "{\"targetType\":\"REFLECTION\",\"targetId\":1}"
+      responses:
+        "201":
+          description: "201"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateLikeResponse"
+              examples:
+                CreateLike:
+                  value: "{\"likeCount\":1,\"liked\":true}"
+    delete:
+      tags:
+      - like
+      summary: Delete Like
+      description: Delete Like
+      operationId: DeleteLike
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateLikeRequest"
+            examples:
+              DeleteLike:
+                value: "{\"targetType\":\"REFLECTION\",\"targetId\":1}"
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateLikeResponse"
+              examples:
+                DeleteLike:
+                  value: "{\"likeCount\":0,\"liked\":false}"
   /media:
     post:
       tags:
@@ -1463,6 +1549,33 @@ paths:
                     :{\"id\":\"1\",\"project\":{\"id\":\"1\",\"name\":\"Project Name\"\
                     ,\"description\":\"Project Description\"},\"title\":\"Post Title\"\
                     ,\"content\":\"Post Content\"}}]}}"
+  /users/{userId}/badges:
+    get:
+      tags:
+      - badge
+      summary: Get Badge Collections
+      description: 유저의 뱃지 도감을 조회합니다.
+      operationId: GetBadgeCollections
+      parameters:
+      - name: userId
+        in: path
+        description: 유저 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetBadgeCollectionsResponse"
+              examples:
+                GetBadgeCollections:
+                  value: "{\"badges\":[{\"id\":1,\"tag\":{\"id\":1,\"name\":\"java\"\
+                    ,\"description\":\"자바 관련 태그\",\"imageUrl\":\"https://example.com/badges/java.png\"\
+                    },\"postCount\":10,\"level\":3,\"createdAt\":\"2026-05-27T10:00:00Z\"\
+                    }]}"
   /users/{userId}/reflections:
     get:
       tags:
@@ -1604,6 +1717,70 @@ components:
                   id:
                     type: number
                     description: Application ID
+    CreateLikeResponse:
+      title: CreateLikeResponse
+      required:
+      - likeCount
+      - liked
+      type: object
+      properties:
+        likeCount:
+          type: number
+          description: Like count
+        liked:
+          type: boolean
+          description: Liked flag
+    GetBadgeCollectionsResponse:
+      title: GetBadgeCollectionsResponse
+      required:
+      - badges
+      type: object
+      properties:
+        badges:
+          type: array
+          description: 뱃지 도감 목록
+          items:
+            required:
+            - createdAt
+            - id
+            - level
+            - postCount
+            - tag
+            type: object
+            properties:
+              createdAt:
+                type: string
+                description: 뱃지 최초 획득 시각
+              level:
+                type: number
+                description: 뱃지 레벨
+              postCount:
+                type: number
+                description: 해당 태그로 작성한 글 수
+              tag:
+                required:
+                - description
+                - id
+                - name
+                type: object
+                properties:
+                  imageUrl:
+                    type: string
+                    description: 뱃지 이미지 URL
+                    nullable: true
+                  name:
+                    type: string
+                    description: 태그 이름
+                  description:
+                    type: string
+                    description: 태그 설명
+                  id:
+                    type: number
+                    description: 태그 ID
+                description: 뱃지 태그
+              id:
+                type: number
+                description: 도감 항목 ID
     CreateJobPostingResponse:
       title: CreateJobPostingResponse
       required:
@@ -1613,6 +1790,73 @@ components:
         id:
           type: string
           description: Job Posting ID
+    GetCommentsResponse:
+      title: GetCommentsResponse
+      required:
+      - comments
+      type: object
+      properties:
+        comments:
+          type: array
+          description: Comments
+          items:
+            required:
+            - createdAt
+            - id
+            - isDeleted
+            - replies
+            - updatedAt
+            type: object
+            properties:
+              createdAt:
+                type: string
+                description: Creation timestamp
+              replies:
+                type: array
+                description: Replies
+                items:
+                  oneOf:
+                  - type: object
+                  - type: boolean
+                  - type: string
+                  - type: number
+              isDeleted:
+                type: boolean
+                description: Is deleted
+              author:
+                required:
+                - handle
+                - id
+                - isPostAuthor
+                - name
+                type: object
+                properties:
+                  isPostAuthor:
+                    type: boolean
+                    description: Whether the author is the post author
+                  name:
+                    type: string
+                    description: Author name
+                  handle:
+                    type: string
+                    description: Author handle
+                  id:
+                    type: number
+                    description: Author user ID
+                  profileImageUrl:
+                    type: string
+                    description: Author profile image URL
+                    nullable: true
+              id:
+                type: number
+                description: Comment ID
+              content:
+                type: string
+                description: Comment content
+                nullable: true
+              updatedAt:
+                type: string
+                description: Update timestamp
     GetProvidersResponse:
       title: GetProvidersResponse
       type: object
@@ -1685,6 +1929,19 @@ components:
                   description: Start Cursor
                   nullable: true
               description: Page Info
+    LoginRequest:
+      title: LoginRequest
+      required:
+      - email
+      - password
+      type: object
+      properties:
+        password:
+          type: string
+          description: Password
+        email:
+          type: string
+          description: Email
     GetProjectsResponse:
       title: GetProjectsResponse
       type: object
@@ -1749,19 +2006,6 @@ components:
                   description: Start Cursor
                   nullable: true
               description: Page Info
-    LoginRequest:
-      title: LoginRequest
-      required:
-      - email
-      - password
-      type: object
-      properties:
-        password:
-          type: string
-          description: Password
-        email:
-          type: string
-          description: Email
     GetBookmarkedReflectionsResponse:
       title: GetBookmarkedReflectionsResponse
       type: object
@@ -1967,6 +2211,19 @@ components:
           type: string
           description: User theme preference
           nullable: true
+    CreateLikeRequest:
+      title: CreateLikeRequest
+      required:
+      - targetId
+      - targetType
+      type: object
+      properties:
+        targetId:
+          type: number
+          description: Like target ID
+        targetType:
+          type: string
+          description: Like target type
     GetFeedResponse:
       title: GetFeedResponse
       type: object
@@ -2085,27 +2342,6 @@ components:
         mediaType:
           type: string
           description: Media Type
-    SearchReflectionsResponse:
-      title: SearchReflectionsResponse
-      required:
-      - reflections
-      type: object
-      properties:
-        reflections:
-          type: array
-          description: Reflection List
-          items:
-            required:
-            - content
-            - id
-            type: object
-            properties:
-              id:
-                type: number
-                description: Reflection ID
-              content:
-                type: string
-                description: Reflection Content
     UpdateProfileRequest:
       title: UpdateProfileRequest
       type: object
@@ -2162,6 +2398,27 @@ components:
           type: boolean
           description: Is Onboarded
           nullable: true
+    SearchReflectionsResponse:
+      title: SearchReflectionsResponse
+      required:
+      - reflections
+      type: object
+      properties:
+        reflections:
+          type: array
+          description: Reflection List
+          items:
+            required:
+            - content
+            - id
+            type: object
+            properties:
+              id:
+                type: number
+                description: Reflection ID
+              content:
+                type: string
+                description: Reflection Content
     SearchResponse:
       title: SearchResponse
       required:
@@ -2389,73 +2646,6 @@ components:
                   updatedAt:
                     type: string
                     description: Update Timestamp
-    GetCommentsResponse:
-      title: GetCommentsResponse
-      required:
-      - comments
-      type: object
-      properties:
-        comments:
-          type: array
-          description: Comments
-          items:
-            required:
-            - createdAt
-            - id
-            - isDeleted
-            - replies
-            - updatedAt
-            type: object
-            properties:
-              createdAt:
-                type: string
-                description: Creation timestamp
-              replies:
-                type: array
-                description: Replies
-                items:
-                  oneOf:
-                  - type: object
-                  - type: boolean
-                  - type: string
-                  - type: number
-              isDeleted:
-                type: boolean
-                description: Is deleted
-              author:
-                required:
-                - handle
-                - id
-                - isPostAuthor
-                - name
-                type: object
-                properties:
-                  isPostAuthor:
-                    type: boolean
-                    description: Whether the author is the post author
-                  name:
-                    type: string
-                    description: Author name
-                  handle:
-                    type: string
-                    description: Author handle
-                  id:
-                    type: number
-                    description: Author user ID
-                  profileImageUrl:
-                    type: string
-                    description: Author profile image URL
-                    nullable: true
-              id:
-                type: number
-                description: Comment ID
-              content:
-                type: string
-                description: Comment content
-                nullable: true
-              updatedAt:
-                type: string
-                description: Update timestamp
     GetUserPreferencesResponse:
       title: GetUserPreferencesResponse
       required:
@@ -2795,6 +2985,31 @@ components:
         status:
           type: string
           description: Application Status
+    SearchTagsResponse:
+      title: SearchTagsResponse
+      required:
+      - tags
+      type: object
+      properties:
+        tags:
+          type: array
+          description: 태그 목록
+          items:
+            required:
+            - description
+            - name
+            - postCount
+            type: object
+            properties:
+              name:
+                type: string
+                description: 태그 이름
+              postCount:
+                type: number
+                description: 태그가 사용된 게시물 수
+              description:
+                type: string
+                description: 태그 설명
     UpdateReflectionRequest:
       title: UpdateReflectionRequest
       required:
@@ -2841,31 +3056,6 @@ components:
             - type: boolean
             - type: string
             - type: number
-    SearchTagsResponse:
-      title: SearchTagsResponse
-      required:
-      - tags
-      type: object
-      properties:
-        tags:
-          type: array
-          description: 태그 목록
-          items:
-            required:
-            - description
-            - name
-            - postCount
-            type: object
-            properties:
-              name:
-                type: string
-                description: 태그 이름
-              postCount:
-                type: number
-                description: 태그가 사용된 게시물 수
-              description:
-                type: string
-                description: 태그 설명
     CreateCommentRequest:
       title: CreateCommentRequest
       required:


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 신규 기능
- Related Issue: Closes #이슈번호

변경 사항에 대한 간략한 설명을 적어주세요.
# 뱃지/도감 서버 구현 설계

## 요약
- 서버 쪽만 구현하고, 웹 변경과 테스트 코드 작성은 제외한다.
- `verified = true`인 `tags`를 뱃지 원본으로 사용한다.
- 유저별 도감 항목은 `badge_collections` 테이블에 저장한다.
- 레벨은 유저별 해당 태그 글 수 기준으로 `1/5/10/20` 구간을 사용한다.

## 주요 변경
- `tags`에 `image_url` 컬럼을 추가한다.
  - DB 컬럼명은 `image_url`, Java/JSON 필드는 `imageUrl`.
- `badge_collections` 테이블과 대응 엔티티를 추가한다.
  - 컬럼: `id`, `user_id`, `tag_id`, `post_count`, `level`, `created_at`, `updated_at`.
  - `UNIQUE(user_id, tag_id)`를 둔다.
  - `post_count`가 0이 되면 도감 항목을 삭제한다.
- 글 생성 시 연결된 태그 중 `verified = true`인 태그만 도감에 반영한다.
- 글 삭제 시 삭제 대상 글의 작성자와 태그를 기준으로 도감 `postCount`를 감소시키고 레벨을 재계산한다.
- 태그 수정 API는 현재 없으므로 태그 변경에 따른 도감 재계산은 이번 범위에 포함하지 않는다.

## API
- `GET /users/{userId}/badges`를 서버에 추가한다.
- 응답 형태:
  - 최상위 필드: `badges`
  - 각 항목: `id`, `tag`, `postCount`, `level`, `createdAt`
  - `tag`: `id`, `name`, `description`, `imageUrl`
- 공개 GET API로 두되, 기존 유저/프로필 조회 정책과 맞춰 존재하지 않거나 비활성 상태로 볼 수 없는 유저는 조회되지 않게 처리한다.

## 구현 방향
- `BadgeCollection` 엔티티, Repository, QueryRepository/QueryService, Controller, Response DTO를 추가한다.
- `BadgeCollectionService`를 추가해 증가/감소와 레벨 계산을 담당한다.
- `TagService.addTagsToReflection(...)`는 기존 태그 생성/연결/전역 태그 카운트 증가를 유지하되, 연결된 `Tag` 목록을 반환하도록 바꾼다.
- `ReflectionService.createReflection(...)`에서 반환된 태그 목록을 `BadgeCollectionService`에 전달한다.
- `ReflectionService.deleteReflection(...)`은 삭제 전에 작성자와 태그를 함께 조회한 뒤, 전역 태그 `postCount`와 도감 카운트를 감소시키고 글을 삭제한다.

## PR Checklist

- [ ] 코드가 정상적으로 빌드되었나요?
- [ ] 적절한 테스트 코드가 추가되었나요? 추가되었다면 아래에 어떤 테스트인지 설명해 주세요.
  - [ ] 테스트 코드 설명
- [ ] 리뷰어 설정이 완료되었나요?

## Other

### 참고사항

- 변경 사항에 대한 추가 설명이 필요하다면 적어주세요.

### Screenshots / Videos (Optional)
