### PR TITLE
fix: 온보딩 이후 세션 상태 동기화 버그 수정

### DIFF
--- a/apps/web/src/components/feature/profile/hooks/useOnboardProfile.ts
+++ b/apps/web/src/components/feature/profile/hooks/useOnboardProfile.ts
@@ -22,7 +22,11 @@ export function useOnboardProfile(options?: UseOnboardProfileOptions) {
           queryKey: getGetAuthenticatedUserQueryKey(),
         });
 
-        await refetchSession();
+        await refetchSession({
+          query: {
+            disableCookieCache: true,
+          },
+        });
 
         options?.onSuccess?.();
       },

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -1,5 +1,6 @@
 import { betterAuth } from 'better-auth';
 import { createAuthMiddleware } from 'better-auth/api';
+import { setSessionCookie } from 'better-auth/cookies';
 import { nextCookies } from 'better-auth/next-js';
 import { HTTPError } from 'ky';
 
@@ -64,6 +65,8 @@ export const auth = betterAuth({
               }
               const sessionCookieHash =
                 await hashSpringSessionCookie(sessionCookie);
+              const forceSync =
+                String(ctx.query?.disableCookieCache) === 'true';
 
               const existingToken = await ctx.getSignedCookie(
                 ctx.context.authCookies.sessionToken.name,
@@ -75,6 +78,7 @@ export const auth = betterAuth({
                   await ctx.context.internalAdapter.findSession(existingToken);
 
                 if (
+                  !forceSync &&
                   existingSession &&
                   new Date(existingSession.session.expiresAt) > new Date() &&
                   existingSession.session.springSessionHash ===
@@ -156,14 +160,7 @@ export const auth = betterAuth({
                 { springSessionHash: sessionCookieHash },
               );
 
-              await ctx.setSignedCookie(
-                ctx.context.authCookies.sessionToken.name,
-                session.token,
-                ctx.context.secret,
-                {
-                  ...ctx.context.authCookies.sessionToken.attributes,
-                },
-              );
+              await setSessionCookie(ctx, { session, user });
 
               return {
                 user,


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 버그 수정
- Related Issue: 없음

온보딩 완료 직후 Better Auth 세션에 최신 온보딩 상태가 반영되지 않던 문제를 수정했습니다.

### 기존 문제

백엔드에서는 온보딩이 정상적으로 완료되어 `isOnboarded`가 `true`로 변경됐지만, Better Auth의 쿠키 캐시에는 기존 값인 `false`가 유지되고 있었습니다.

또한 온보딩 전후로 Spring Session 쿠키 값이 동일하기 때문에, 세션 동기화 훅이 동일한 로그인 세션으로 판단하고 백엔드 사용자 정보를 다시 조회하지 않았습니다.

그 결과 온보딩을 마친 사용자가 초안 페이지 등의 일반 페이지에 접근하면 `/onboarding`으로 이동했다가 다시 홈으로 돌아오는 문제가 발생했습니다.

### 해결 방법

- 온보딩 성공 후 Better Auth 세션을 다시 조회할 때 `disableCookieCache` 옵션을 사용하도록 변경했습니다.
- 강제 동기화 요청에서는 Spring Session 해시가 같더라도 기존 세션을 재사용하지 않고 백엔드의 최신 사용자 정보를 조회하도록 변경했습니다.
- 세션 토큰만 직접 설정하는 대신 Better Auth의 `setSessionCookie`를 사용해 세션 데이터 캐시 쿠키까지 함께 갱신하도록 변경했습니다.

이제 온보딩 완료 직후 `isOnboarded`가 `true`로 갱신되며, 이후 요청에서도 최신 상태가 유지됩니다.

## PR Checklist

- [x] 코드가 정상적으로 빌드되었나요?
- [ ] 적절한 테스트 코드가 추가되었나요?
  - 별도의 자동화 테스트 코드는 추가하지 않았습니다.
  - 로컬에서 실제 온보딩 상태 전환과 페이지 접근을 회귀 검증했습니다.
- [ ] 리뷰어 설정이 완료되었나요?

## Other

### 참고사항


### Screenshots / Videos (Optional)

없음