### PR TITLE
fix: 이메일 인증 코드 입력 처리 개선

### DIFF
--- a/apps/web/public/locales/ko.json
+++ b/apps/web/public/locales/ko.json
@@ -756,7 +756,8 @@
           },
           "errors": {
             "send": "인증 코드를 보내지 못했어요. 다시 시도해주세요.",
-            "invalidToken": "인증 코드가 올바르지 않아요."
+            "invalidToken": "인증 코드가 올바르지 않아요.",
+            "useEnglishInput": "영문 입력으로 전환해주세요."
           }
         },
         "finished": {

--- a/apps/web/src/app/onboarding/_components/EmailVerificationStep.tsx
+++ b/apps/web/src/app/onboarding/_components/EmailVerificationStep.tsx
@@ -26,6 +26,15 @@ import SyncError, { ErrorCode } from '@/lib/error';
 
 import { OnboardingStepContentProps, OnboardingStepContentRef } from '../page';
 
+const EMAIL_VERIFICATION_TOKEN_LENGTH = 6;
+const HANGUL_PATTERN = /\p{Script=Hangul}/u;
+
+const sanitizeVerificationToken = (value: string) =>
+  value
+    .toUpperCase()
+    .replace(/[^A-Z]/g, '')
+    .slice(0, EMAIL_VERIFICATION_TOKEN_LENGTH);
+
 export const EmailVerificationStep = forwardRef<
   OnboardingStepContentRef,
   OnboardingStepContentProps
@@ -121,6 +130,11 @@ export const EmailVerificationStep = forwardRef<
     sendVerificationEmail();
   };
 
+  const tokenChangeHandler = (value: string) => {
+    setToken(sanitizeVerificationToken(value));
+    setError(HANGUL_PATTERN.test(value) ? t('errors.useEnglishInput') : null);
+  };
+
   const verifyClickHandler = () => {
     setError(null);
     verifyEmail({ data: { token } });
@@ -152,8 +166,10 @@ export const EmailVerificationStep = forwardRef<
           <div className="flex gap-2">
             <Input
               value={token}
-              onChange={(event) => setToken(event.target.value)}
+              onChange={(event) => tokenChangeHandler(event.target.value)}
+              autoComplete="one-time-code"
               placeholder={t('form.token.placeholder')}
+              spellCheck={false}
             />
             <Button
               type="button"


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 버그 수정

온보딩 이메일 인증 코드 입력 UX를 개선했습니다.

- 붙여넣기 및 직접 입력 시 공백과 유효하지 않은 문자 제거
- 영문 소문자를 대문자로 변환하고 인증 코드 길이를 6자로 제한
- 한글 입력이 감지되면 `영문 입력으로 전환해주세요.` 안내 표시
- 인증 코드 자동 완성을 지원하도록 `autocomplete="one-time-code"` 적용


## PR Checklist

- [x] 코드가 정상적으로 빌드되었나요?
- [ ] 적절한 테스트 코드가 추가되었나요? 추가되었다면 아래에 어떤 테스트인지 설명해 주세요.
  - [ ] 테스트 코드 설명
- [ ] 리뷰어 설정이 완료되었나요?

## Other

### 참고사항

### Screenshots / Videos (Optional)
