### PR TITLE
fix: 인기 게시물에서 비공개 프로젝트 게시글 제외

### DIFF
--- a/apps/server/src/main/java/com/skkil/sync/post/repository/PostRecommendationQueryRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/post/repository/PostRecommendationQueryRepository.java
@@ -39,6 +39,20 @@ public class PostRecommendationQueryRepository {
    */
   public CursorPaginationDataFetcher<PostRecommendationCandidate> getCandidates(
       Condition channelCondition, PostRecommendationContext context) {
+    return getCandidates(
+        channelCondition, context, PostConditions.readablePublished(context.requesterId()));
+  }
+
+  /** 공개 탐색 화면에 노출할 수 있는 게시글만 추천 후보로 조회한다. 요청자가 비공개 프로젝트의 팀원이더라도 해당 프로젝트의 게시글은 탐색 후보에서 제외한다. */
+  public CursorPaginationDataFetcher<PostRecommendationCandidate> getDiscoveryCandidates(
+      Condition channelCondition, PostRecommendationContext context) {
+    return getCandidates(channelCondition, context, PostConditions.feedVisible());
+  }
+
+  private CursorPaginationDataFetcher<PostRecommendationCandidate> getCandidates(
+      Condition channelCondition,
+      PostRecommendationContext context,
+      Condition visibilityCondition) {
     return (condition, orderFields, size) ->
         dsl.select(
                 POSTS.ID.as("id"),
@@ -49,7 +63,7 @@ public class PostRecommendationQueryRepository {
             .on(POSTS.PROJECT_ID.eq(PROJECTS.ID))
             .where(
                 condition
-                    .and(PostConditions.readablePublished(context.requesterId()))
+                    .and(visibilityCondition)
                     .and(scopeCondition(context.scope()))
                     .and(channelCondition))
             .orderBy(orderFields)

--- a/apps/server/src/main/java/com/skkil/sync/post/service/recommendation/TrendingPostRecommendationChannel.java
+++ b/apps/server/src/main/java/com/skkil/sync/post/service/recommendation/TrendingPostRecommendationChannel.java
@@ -28,7 +28,7 @@ public class TrendingPostRecommendationChannel implements PostRecommendationChan
   @Override
   public CursorPaginationDataFetcher<PostRecommendationCandidate> getCandidateFetcher(
       PostRecommendationContext context) {
-    return postRecommendationQueryRepository.getCandidates(
+    return postRecommendationQueryRepository.getDiscoveryCandidates(
         postRecommendationQueryRepository.trendingCondition(), context);
   }
 

--- a/apps/server/src/main/resources/application.yaml
+++ b/apps/server/src/main/resources/application.yaml
@@ -75,6 +75,11 @@ spring:
     model:
       chat: ${AI_CHAT_PROVIDER:none}
       embedding: ${AI_EMBEDDING_PROVIDER:none}
+      audio:
+        speech: none
+        transcription: none
+      image: none
+      moderation: none
     ollama:
       base-url: ${OLLAMA_URL:http://localhost:11434}
       chat:

--- a/apps/server/src/test/java/com/skkil/sync/post/repository/PostRecommendationQueryRepositoryTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/post/repository/PostRecommendationQueryRepositoryTests.java
@@ -1,0 +1,118 @@
+package com.skkil.sync.post.repository;
+
+import static com.skkil.sync.jooq.tables.Posts.POSTS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.skkil.sync.common.config.TestcontainersConfig;
+import com.skkil.sync.config.JpaConfig;
+import com.skkil.sync.post.dto.data.PostRecommendationCandidate;
+import com.skkil.sync.post.dto.data.PostRecommendationContext;
+import com.skkil.sync.post.model.Post;
+import com.skkil.sync.post.model.PostScope;
+import com.skkil.sync.post.model.PostStatus;
+import com.skkil.sync.post.model.PostType;
+import com.skkil.sync.project.model.Project;
+import com.skkil.sync.project.model.Teammate;
+import com.skkil.sync.project.repository.ProjectRepository;
+import com.skkil.sync.project.repository.TeammateRepository;
+import com.skkil.sync.user.model.User;
+import com.skkil.sync.user.repository.UserRepository;
+import java.util.List;
+import org.jooq.impl.DSL;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({TestcontainersConfig.class, JpaConfig.class, PostRecommendationQueryRepository.class})
+class PostRecommendationQueryRepositoryTests {
+
+  @Autowired private PostRecommendationQueryRepository postRecommendationQueryRepository;
+
+  @Autowired private PostRepository postRepository;
+
+  @Autowired private ProjectRepository projectRepository;
+
+  @Autowired private TeammateRepository teammateRepository;
+
+  @Autowired private UserRepository userRepository;
+
+  @Test
+  @DisplayName("[인기 게시글] 요청자가 팀원이어도 비공개 프로젝트 게시글은 탐색 후보에서 제외한다")
+  void getDiscoveryCandidates_excludesPrivateProjectPostForTeammate() {
+    User author = saveUser("trending-author");
+    Project privateProject = saveProject("trending-private", false);
+    Project publicProject = saveProject("trending-public", true);
+    teammateRepository.saveAndFlush(Teammate.owner(privateProject, author));
+
+    Post privatePost = savePost("trending-private-post", author, privateProject);
+    Post publicPost = savePost("trending-public-post", author, publicProject);
+    Post personalPost = savePost("trending-personal-post", author, null);
+
+    List<PostRecommendationCandidate> candidates =
+        getDiscoveryCandidates(new PostRecommendationContext(author.getId(), null));
+
+    assertThat(candidates)
+        .extracting(PostRecommendationCandidate::id)
+        .containsExactlyInAnyOrder(publicPost.getId(), personalPost.getId())
+        .doesNotContain(privatePost.getId());
+  }
+
+  @Test
+  @DisplayName("[프로젝트 인기 게시글] 공개 프로젝트 게시글만 탐색 후보에 포함한다")
+  void getDiscoveryCandidates_workspaceScopeIncludesOnlyPublicProjectPosts() {
+    User author = saveUser("workspace-trending-author");
+    Project privateProject = saveProject("workspace-trending-private", false);
+    Project publicProject = saveProject("workspace-trending-public", true);
+    teammateRepository.saveAndFlush(Teammate.owner(privateProject, author));
+
+    Post privatePost = savePost("workspace-trending-private-post", author, privateProject);
+    Post publicPost = savePost("workspace-trending-public-post", author, publicProject);
+    Post personalPost = savePost("workspace-trending-personal-post", author, null);
+
+    List<PostRecommendationCandidate> candidates =
+        getDiscoveryCandidates(new PostRecommendationContext(author.getId(), PostScope.WORKSPACE));
+
+    assertThat(candidates)
+        .extracting(PostRecommendationCandidate::id)
+        .containsExactly(publicPost.getId())
+        .doesNotContain(privatePost.getId(), personalPost.getId());
+  }
+
+  private List<PostRecommendationCandidate> getDiscoveryCandidates(
+      PostRecommendationContext context) {
+    return postRecommendationQueryRepository
+        .getDiscoveryCandidates(postRecommendationQueryRepository.trendingCondition(), context)
+        .fetch(DSL.noCondition(), List.of(POSTS.LIKE_COUNT.desc(), POSTS.ID.desc()), 10);
+  }
+
+  private User saveUser(String key) {
+    return userRepository.saveAndFlush(
+        User.builder().email(key + "@example.com").fullName("사용자").build());
+  }
+
+  private Project saveProject(String handle, boolean isPublic) {
+    return projectRepository.saveAndFlush(
+        Project.builder().handle(handle).name(handle).isPublic(isPublic).build());
+  }
+
+  private Post savePost(String slug, User author, @Nullable Project project) {
+    Post post =
+        Post.builder()
+            .slug(slug)
+            .author(author)
+            .project(project)
+            .type(PostType.SHORT)
+            .status(PostStatus.PUBLISHED)
+            .content("본문")
+            .build();
+    post.updateContent("본문", "본문", 0);
+
+    return postRepository.saveAndFlush(post);
+  }
+}


### PR DESCRIPTION
## 개요

인기 게시물 추천에서 로그인 사용자가 소유하거나 참여 중인 비공개 프로젝트의 게시글이 노출되던 문제를 수정합니다.

이 변경으로 다음 두 화면의 인기 게시물은 사용자 권한과 무관하게 공개 탐색이 가능한 게시글만 표시합니다.

- 탐색 탭의 전체 인기 게시물
- 프로젝트 탐색 탭의 인기 포스트

## 문제 상황

기존 추천 후보 조회는 모든 추천 채널에서 `PostConditions.readablePublished(requesterId)`를 공통으로 사용했습니다.

이 조건은 사용자가 읽을 수 있는 게시글을 판단하기 위한 조건이므로 다음 게시글을 모두 허용합니다.

- 발행된 개인 게시글
- 공개 프로젝트의 발행된 게시글
- 요청자가 팀원인 비공개 프로젝트의 발행된 게시글

따라서 비공개 프로젝트의 소유자, 관리자 또는 멤버로 로그인한 사용자는 해당 프로젝트의 게시글을 프로젝트 내부뿐 아니라 전역 인기 게시물에서도 볼 수 있었습니다. 프로젝트 탐색 탭의 인기 포스트 역시 같은 `TRENDING` 추천 API를 `WORKSPACE` 범위로 호출하기 때문에 동일한 문제가 발생했습니다.

읽을 권한이 있다는 사실과 전역 탐색 화면에 노출해도 된다는 사실은 서로 다른 정책입니다. 비공개 프로젝트 게시글은 프로젝트 내부에서는 읽을 수 있어야 하지만, 인기 게시물과 같은 전역 탐색 영역에서는 사용자 권한과 관계없이 제외되어야 합니다.

## 원인

추천 저장소가 다음 두 개념을 하나의 조건으로 처리하고 있었습니다.

1. **열람 가능성**: 현재 사용자가 해당 게시글을 읽을 수 있는가
2. **탐색 노출 가능성**: 해당 게시글을 전역 탐색 및 인기 목록에 노출해도 되는가

`TRENDING` 채널은 공개 탐색 성격의 채널이지만, 권한 기반 열람 조건을 사용해 비공개 프로젝트 팀원의 게시글까지 후보에 포함했습니다.

## 변경 사항

### 1. 추천 후보 조회 정책 분리

`PostRecommendationQueryRepository`에 공개 탐색 전용 후보 조회 경로인 `getDiscoveryCandidates`를 추가했습니다.

- 기존 `getCandidates`
  - `readablePublished(requesterId)` 사용
  - 사용자 권한을 반영하는 추천 채널에서 기존 동작 유지
- 신규 `getDiscoveryCandidates`
  - `feedVisible()` 사용
  - 발행된 개인 게시글과 공개 프로젝트의 발행된 게시글만 포함
  - 요청자가 비공개 프로젝트 팀원이어도 해당 프로젝트 게시글 제외

공통 SQL 생성 부분은 private 오버로드로 추출해 범위, 채널 및 페이지네이션 조건이 중복되지 않도록 구성했습니다.

### 2. `TRENDING` 채널에 공개 탐색 정책 적용

`TrendingPostRecommendationChannel`이 일반 권한 기반 후보 대신 공개 탐색 후보를 조회하도록 변경했습니다.

이에 따라:

- 전체 인기 게시물에는 개인 게시글과 공개 프로젝트 게시글만 노출됩니다.
- `scope=WORKSPACE`를 사용하는 프로젝트 탐색의 인기 포스트에는 공개 프로젝트 게시글만 노출됩니다.
- 비공개 프로젝트 게시글은 소유자·관리자·멤버 여부와 관계없이 두 화면에서 제외됩니다.
- 홈 피드의 `FOLLOWING` 등 다른 추천 채널은 기존 권한 기반 동작을 유지합니다.

### 3. 저장소 회귀 테스트 추가

`PostRecommendationQueryRepositoryTests`를 추가해 실제 데이터베이스 조건을 검증합니다.

검증 시나리오:

- 비공개 프로젝트 팀원에게도 해당 프로젝트 게시글이 인기 탐색 후보로 노출되지 않는지 확인
- 공개 프로젝트 게시글은 인기 탐색 후보에 포함되는지 확인
- 개인 게시글은 전체 인기 탐색 후보에 포함되는지 확인
- `WORKSPACE` 범위에서는 공개 프로젝트 게시글만 포함되는지 확인
- `WORKSPACE` 범위에서 개인 게시글과 비공개 프로젝트 게시글이 모두 제외되는지 확인

## 변경 전후

| 구분 | 변경 전 | 변경 후 |
| --- | --- | --- |
| 개인 발행 게시글 | 인기 게시물에 노출 | 인기 게시물에 노출 |
| 공개 프로젝트 발행 게시글 | 인기 게시물에 노출 | 인기 게시물에 노출 |
| 비공개 프로젝트 발행 게시글 | 팀원에게 인기 게시물로 노출 | 모든 사용자에게 인기 게시물에서 제외 |
| `FOLLOWING` 등 권한 기반 추천 | 권한에 따라 노출 | 기존 동작 유지 |

## 사용자 및 개발 영향

- 비공개 프로젝트의 제목, 미리보기 및 활동 정보가 전역 인기 영역에 노출되지 않습니다.
- 프로젝트 내부 열람 권한에는 변화가 없습니다.
- 프론트엔드에서 사후 필터링하지 않고 데이터베이스 후보 조회 단계에서 제외하므로 페이지 개수와 커서 페이지네이션의 정확성을 유지합니다.
- 두 화면이 동일한 `TRENDING` API를 사용하므로 별도의 프론트엔드 변경 없이 함께 수정됩니다.

## 검증

다음 명령을 최신 `origin/develop` 기준으로 실행했습니다.

```bash
./gradlew spotlessCheck test \
  --tests 'com.skkil.sync.post.repository.PostRecommendationQueryRepositoryTests' \
  --tests 'com.skkil.sync.post.controller.PostRecommendationControllerTests'
```

결과: `BUILD SUCCESSFUL`

## 관련 범위

이 PR은 인기 게시물의 탐색 노출 정책만 변경합니다. 게시글 상세 조회, 프로젝트 내부 게시글 조회 및 다른 개인화 추천 채널의 접근 권한 정책은 변경하지 않습니다.

## CI 실패 원인 및 해결

최신 `develop`에 OpenAI 임베딩 starter가 추가된 뒤, API 키가 없는 CI 환경에서 사용하지 않는 OpenAI 음성 합성 모델 자동 구성이 기본 활성화되었습니다. 그 결과 `openAiAudioSpeechModel` Bean 생성 시 `OpenAI API key must be set` 예외가 발생해 애플리케이션 컨텍스트와 세션 통합 테스트가 연쇄 실패했습니다.

`spring.ai.model.audio.speech`, `audio.transcription`, `image`, `moderation`을 명시적으로 `none`으로 설정해 실제 사용하는 채팅·임베딩 모델만 환경 변수로 선택되도록 수정했습니다.

추가 검증:

- OpenAI API 키가 없는 조건에서 `SyncApplicationTests` 통과
- 실패했던 `PasswordSessionInvalidationIntegrationTests` 3개 통과
- 추천 저장소 및 컨트롤러 회귀 테스트 통과
- `./scripts/ci/build-server.sh` 전체 빌드 통과 (`BUILD SUCCESSFUL`)
