### PR TITLE
fix: 프로젝트 설정·편집기의 워크스페이스 용어를 프로젝트로 통일

### DIFF
--- a/apps/web/public/locales/ko.json
+++ b/apps/web/public/locales/ko.json
@@ -519,11 +519,11 @@
         },
         "settings": {
           "tabs": {
-            "workspace": "워크스페이스",
+            "project": "프로젝트",
             "teammates": "팀원"
           },
-          "workspace": {
-            "heading": "워크스페이스 설정",
+          "project": {
+            "heading": "프로젝트 설정",
             "description": "프로젝트의 기본 정보를 관리합니다.",
             "icon": {
               "heading": "프로젝트 아이콘",
@@ -574,12 +574,12 @@
               "heading": "위험 구역",
               "description": "이 작업은 되돌릴 수 없습니다. 신중하게 진행하세요.",
               "leave": {
-                "title": "워크스페이스 나가기",
+                "title": "프로젝트 나가기",
                 "description": "이 프로젝트에서 탈퇴합니다.",
                 "action": "나가기"
               },
               "delete": {
-                "title": "워크스페이스 삭제",
+                "title": "프로젝트 삭제",
                 "description": "프로젝트와 모든 데이터를 영구적으로 삭제합니다.",
                 "action": "삭제"
               }
@@ -635,7 +635,7 @@
             },
             "remove-dialog": {
               "title": "팀원을 삭제할까요?",
-              "description": "{name}님을 이 워크스페이스에서 삭제합니다.",
+              "description": "{name}님을 이 프로젝트에서 삭제합니다.",
               "cancel": "취소",
               "confirm": "삭제"
             },
@@ -644,7 +644,7 @@
               "update-error": "팀원 역할 수정에 실패했습니다.",
               "remove-success": "팀원을 삭제했습니다.",
               "remove-error": "팀원 삭제에 실패했습니다.",
-              "owner-protected": "워크스페이스 소유자는 수정하거나 삭제할 수 없습니다.",
+              "owner-protected": "프로젝트 소유자는 수정하거나 삭제할 수 없습니다.",
               "cancel-success": "초대를 취소했습니다.",
               "cancel-error": "초대 취소에 실패했습니다.",
               "approve-success": "가입 요청을 승인했습니다.",
@@ -1982,9 +1982,9 @@
       },
       "scope": {
         "public": "공개",
-        "workspace": "워크스페이스: {workspace}",
-        "workspace-generic": "워크스페이스",
-        "workspace-loading": "불러오는 중"
+        "project": "프로젝트: {project}",
+        "project-generic": "프로젝트",
+        "project-loading": "불러오는 중"
       },
       "validation": {
         "title-required": "게시하려면 제목을 입력해주세요."

--- a/apps/web/src/app/(app)/projects/[handle]/posts/new/page.tsx
+++ b/apps/web/src/app/(app)/projects/[handle]/posts/new/page.tsx
@@ -38,7 +38,7 @@ export default function CreateProjectPostPage() {
       isSubmitting={isCreatingPost || !projectData}
       project={{
         handle,
-        name: projectData?.data.summary.name ?? t('workspace-loading'),
+        name: projectData?.data.summary.name ?? t('project-loading'),
       }}
       onSubmit={({
         title,

--- a/apps/web/src/app/(app)/projects/[handle]/settings/_components/ProjectSettingsView.tsx
+++ b/apps/web/src/app/(app)/projects/[handle]/settings/_components/ProjectSettingsView.tsx
@@ -41,8 +41,8 @@ const PROJECT_NAME_MAX_LENGTH = 50;
 const PROJECT_HANDLE_MIN_LENGTH = 6;
 const PROJECT_HANDLE_MAX_LENGTH = 30;
 
-export default function WorkspaceSettingsView() {
-  const t = useTranslations('pages.projects.project.settings.workspace');
+export default function ProjectSettingsView() {
+  const t = useTranslations('pages.projects.project.settings.project');
 
   const { handle } = useParams<{ handle: string }>();
   const { data, isPending } = useGetProjectByHandle(handle);
@@ -52,7 +52,7 @@ export default function WorkspaceSettingsView() {
   const isMember = project?.role != null;
 
   if (isPending) {
-    return <WorkspaceSettingsSkeleton />;
+    return <ProjectSettingsSkeleton />;
   }
 
   return (
@@ -166,7 +166,7 @@ function ProjectIconField({
   handle: string;
   isAdmin: boolean;
 }) {
-  const t = useTranslations('pages.projects.project.settings.workspace.icon');
+  const t = useTranslations('pages.projects.project.settings.project.icon');
 
   const { data } = useGetProjectByHandle(handle);
   const project = data?.data;
@@ -339,7 +339,7 @@ function ProjectNameField({
   handle: string;
   isAdmin: boolean;
 }) {
-  const t = useTranslations('pages.projects.project.settings.workspace.name');
+  const t = useTranslations('pages.projects.project.settings.project.name');
 
   const { data } = useGetProjectByHandle(handle);
   const project = data?.data;
@@ -429,7 +429,7 @@ function ProjectHandleField({
   handle: string;
   isAdmin: boolean;
 }) {
-  const t = useTranslations('pages.projects.project.settings.workspace.handle');
+  const t = useTranslations('pages.projects.project.settings.project.handle');
   const router = useRouter();
 
   const { data } = useGetProjectByHandle(handle);
@@ -524,7 +524,7 @@ function ProjectJoinPolicyField({
   isAdmin: boolean;
 }) {
   const t = useTranslations(
-    'pages.projects.project.settings.workspace.join-policy',
+    'pages.projects.project.settings.project.join-policy',
   );
 
   const { data } = useGetProjectByHandle(handle);
@@ -605,7 +605,7 @@ function ProjectJoinPolicyField({
   );
 }
 
-function WorkspaceSettingsSkeleton() {
+function ProjectSettingsSkeleton() {
   return (
     <div className="max-w-2xl space-y-6">
       <div className="space-y-2">

--- a/apps/web/src/app/(app)/projects/[handle]/settings/_components/SettingsTabs.tsx
+++ b/apps/web/src/app/(app)/projects/[handle]/settings/_components/SettingsTabs.tsx
@@ -23,8 +23,8 @@ export default function SettingsTabs({ children }: SettingsTabsProps) {
     href: (handle: string) => string;
   }[] = [
     {
-      id: 'workspace',
-      label: t('workspace'),
+      id: 'project',
+      label: t('project'),
       href: ROUTES.PROJECT_SETTINGS,
     },
     {

--- a/apps/web/src/app/(app)/projects/[handle]/settings/page.tsx
+++ b/apps/web/src/app/(app)/projects/[handle]/settings/page.tsx
@@ -7,23 +7,23 @@ import { getGetProjectByHandleQueryOptions } from '@/api/__generated__/project/p
 import SyncError, { ErrorCode } from '@/lib/error';
 import { getQueryClient } from '@/lib/query';
 
-import WorkspaceSettingsView from './_components/WorkspaceSettingsView';
+import ProjectSettingsView from './_components/ProjectSettingsView';
 
-interface WorkspaceSettingsPageProps {
+interface ProjectSettingsPageProps {
   params: Promise<{
     handle: string;
   }>;
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations('pages.projects.project.settings.workspace');
+  const t = await getTranslations('pages.projects.project.settings.project');
 
   return { title: t('heading') };
 }
 
-export default async function WorkspaceSettingsPage({
+export default async function ProjectSettingsPage({
   params,
-}: WorkspaceSettingsPageProps) {
+}: ProjectSettingsPageProps) {
   const { handle } = await params;
 
   const queryClient = getQueryClient();
@@ -41,7 +41,7 @@ export default async function WorkspaceSettingsPage({
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <WorkspaceSettingsView />
+      <ProjectSettingsView />
     </HydrationBoundary>
   );
 }

--- a/apps/web/src/components/feature/post/editor/PostEditor.tsx
+++ b/apps/web/src/components/feature/post/editor/PostEditor.tsx
@@ -384,9 +384,9 @@ export default function PostEditor({
       ? t('placeholders.title-question')
       : t('placeholders.title-long');
   const scopeLabel = project
-    ? t('scope.workspace', { workspace: project.name })
+    ? t('scope.project', { project: project.name })
     : initialScope === PostScope.WORKSPACE
-      ? t('scope.workspace-generic')
+      ? t('scope.project-generic')
       : t('scope.public');
   const canSaveDraft = !isEditing || initialStatus === PostStatus.DRAFT;
   const draftActionLabel = isEditing


### PR DESCRIPTION
## 변경 배경

SYNC에서는 사용자가 글과 팀 지식을 구성하는 공간을 일관되게 **프로젝트**라고 부르고 있습니다. 그러나 프로젝트 설정 화면과 게시글 편집기의 일부 문구에는 이전 명칭인 **워크스페이스**가 남아 있었습니다.

이 때문에 프로젝트 목록·상세 화면에서는 `프로젝트`로 표시되지만, 같은 대상을 설정 탭이나 편집기에서는 `워크스페이스`라고 표시하는 용어 불일치가 발생했습니다. 사용자 노출 문구뿐 아니라 설정 컴포넌트 이름과 `next-intl` 번역 네임스페이스에도 과거 명칭이 남아 있어 이후 문구를 추가할 때 불일치가 반복될 여지가 있었습니다.

이번 PR은 사용자에게 보이는 명칭과 관련 프론트엔드 내부 이름을 `프로젝트`로 통일합니다.

## 주요 변경 사항

### 1. 프로젝트 설정 화면 문구 통일

프로젝트 설정 화면에 남아 있던 문구를 다음과 같이 변경했습니다.

| 기존 문구 | 변경 문구 |
| --- | --- |
| 워크스페이스 | 프로젝트 |
| 워크스페이스 설정 | 프로젝트 설정 |
| 워크스페이스 나가기 | 프로젝트 나가기 |
| 워크스페이스 삭제 | 프로젝트 삭제 |
| 이 워크스페이스에서 삭제합니다 | 이 프로젝트에서 삭제합니다 |
| 워크스페이스 소유자 | 프로젝트 소유자 |

프로젝트 설정 탭, 기본 설정 제목, 위험 구역, 팀원 삭제 확인창과 소유자 보호 안내에서 동일한 제품 용어를 사용하도록 정리했습니다.

### 2. 게시글 편집기의 프로젝트 범위 문구 변경

프로젝트 게시글을 작성할 때 편집기에 표시되는 범위 문구를 다음과 같이 변경했습니다.

```text
워크스페이스: {이름}
```

```text
프로젝트: {이름}
```

프로젝트 정보를 아직 불러오지 못한 상태에서 사용하는 일반 범위 문구와 로딩 번역 키도 `project` 기준으로 변경했습니다.

### 3. 번역 키와 보간 변수 정리

화면 문구와 각 호출부가 동일한 용어를 사용하도록 `next-intl` 키를 함께 변경했습니다.

- `settings.tabs.workspace` → `settings.tabs.project`
- `settings.workspace` → `settings.project`
- `scope.workspace` → `scope.project`
- `scope.workspace-generic` → `scope.project-generic`
- `scope.workspace-loading` → `scope.project-loading`
- 번역 보간 변수 `{workspace}` → `{project}`

번역 리소스와 호출부를 동시에 변경해 이전 키를 참조하는 활성 코드가 남지 않도록 했습니다.

### 4. 설정 컴포넌트 내부 명칭 변경

프로젝트 설정 페이지의 파일·컴포넌트·타입 이름도 현재 제품 용어에 맞게 정리했습니다.

- `WorkspaceSettingsView.tsx` → `ProjectSettingsView.tsx`
- `WorkspaceSettingsView` → `ProjectSettingsView`
- `WorkspaceSettingsSkeleton` → `ProjectSettingsSkeleton`
- `WorkspaceSettingsPage` → `ProjectSettingsPage`
- `WorkspaceSettingsPageProps` → `ProjectSettingsPageProps`
- 설정 탭 내부 ID `workspace` → `project`

파일 이름, import, 페이지 컴포넌트와 스켈레톤 이름을 함께 변경했으며 기존 설정 저장 로직은 그대로 유지했습니다.

## 변경하지 않은 항목

이번 PR은 사용자 표시 문구와 프론트엔드 명명 체계를 정리하는 변경입니다. 다음 기술 계약과 동작은 변경하지 않았습니다.

- `PostScope.WORKSPACE`
- `CollectionScope.WORKSPACE`
- 프로젝트 설정 URL과 라우팅 구조
- 프로젝트 API 요청·응답 계약
- 데이터베이스 구조
- 프로젝트 접근 권한 및 설정 저장 동작

`WORKSPACE` enum은 개인 글과 프로젝트 글의 범위를 구분하는 내부 도메인 값이므로 사용자에게 표시되는 명칭과 별개로 유지합니다.

## 영향 범위

- 프로젝트 설정 탭 및 기본 설정 화면
- 프로젝트 나가기·삭제 안내
- 팀원 삭제 및 소유자 보호 안내
- 프로젝트 게시글 작성 화면의 범위 표시
- 관련 번역 네임스페이스와 설정 컴포넌트 명칭

데이터 처리, 권한 판정 또는 API 동작 변경은 없습니다.

## 테스트 및 검증

- [x] `pnpm exec prettier --check .`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] Orval API 클라이언트 재생성 후 추가 변경 없음 확인
- [x] TypeScript 검사 및 Next.js 프로덕션 빌드 통과
- [x] 활성 웹 코드의 사용자 노출 `워크스페이스` 문구 잔여 0건 확인
- [x] `PostScope.WORKSPACE` 등 내부 도메인 계약 유지 확인

## 리뷰 포인트

- 설정 화면과 편집기의 사용자 노출 명칭이 `프로젝트`로 일관되게 표시되는지
- 변경된 번역 키와 호출부가 서로 일치하는지
- 설정 컴포넌트 파일 변경 이후 import 또는 렌더링 누락이 없는지
- 내부 도메인 enum과 사용자 표시 용어의 경계가 유지되는지