### PR TITLE
feat: 홈 추천 피드 안정화 및 태그 팔로우 연동

### DIFF
--- a/apps/server/src/main/java/com/skkil/sync/post/controller/PostRecommendationController.java
+++ b/apps/server/src/main/java/com/skkil/sync/post/controller/PostRecommendationController.java
@@ -6,6 +6,7 @@ import com.skkil.sync.post.dto.data.PostRecommendationContext;
 import com.skkil.sync.post.dto.response.PaginatedGetPostsResponse;
 import com.skkil.sync.post.model.PostRecommendationType;
 import com.skkil.sync.post.model.PostScope;
+import com.skkil.sync.post.model.PostType;
 import com.skkil.sync.post.service.PostRecommendationService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -30,8 +31,9 @@ public class PostRecommendationController {
       @AuthenticationPrincipal AuthenticatedUser user,
       @RequestParam(required = false) PostRecommendationType type,
       @RequestParam(required = false) PostScope scope,
+      @RequestParam(required = false) PostType postType,
       @Validated CursorPaginationRequest pagination) {
-    var context = new PostRecommendationContext(user.userId(), scope);
+    var context = new PostRecommendationContext(user.userId(), scope, postType);
     return postRecommendationService.getRecommendations(context, type, pagination);
   }
 }

--- a/apps/server/src/main/java/com/skkil/sync/post/dto/data/PostRecommendationContext.java
+++ b/apps/server/src/main/java/com/skkil/sync/post/dto/data/PostRecommendationContext.java
@@ -1,6 +1,8 @@
 package com.skkil.sync.post.dto.data;
 
 import com.skkil.sync.post.model.PostScope;
+import com.skkil.sync.post.model.PostType;
 import org.jspecify.annotations.Nullable;
 
-public record PostRecommendationContext(Long requesterId, @Nullable PostScope scope) {}
+public record PostRecommendationContext(
+    Long requesterId, @Nullable PostScope scope, @Nullable PostType postType) {}

--- a/apps/server/src/main/java/com/skkil/sync/post/repository/PostRecommendationQueryRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/post/repository/PostRecommendationQueryRepository.java
@@ -1,14 +1,18 @@
 package com.skkil.sync.post.repository;
 
+import static com.skkil.sync.jooq.tables.PostTags.POST_TAGS;
 import static com.skkil.sync.jooq.tables.Posts.POSTS;
 import static com.skkil.sync.jooq.tables.ProjectFollowRelationships.PROJECT_FOLLOW_RELATIONSHIPS;
 import static com.skkil.sync.jooq.tables.Projects.PROJECTS;
+import static com.skkil.sync.jooq.tables.TagFollowRelationships.TAG_FOLLOW_RELATIONSHIPS;
+import static com.skkil.sync.jooq.tables.Tags.TAGS;
 import static com.skkil.sync.jooq.tables.UserFollowRelationships.USER_FOLLOW_RELATIONSHIPS;
 
 import com.skkil.sync.common.util.pagination.interfaces.CursorPaginationDataFetcher;
 import com.skkil.sync.post.dto.data.PostRecommendationCandidate;
 import com.skkil.sync.post.dto.data.PostRecommendationContext;
 import com.skkil.sync.post.model.PostScope;
+import com.skkil.sync.post.model.PostType;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import org.jooq.Condition;
@@ -65,6 +69,7 @@ public class PostRecommendationQueryRepository {
                 condition
                     .and(visibilityCondition)
                     .and(scopeCondition(context.scope()))
+                    .and(postTypeCondition(context.postType()))
                     .and(channelCondition))
             .orderBy(orderFields)
             .limit(size)
@@ -84,7 +89,19 @@ public class PostRecommendationQueryRepository {
                     .from(PROJECT_FOLLOW_RELATIONSHIPS)
                     .where(
                         PROJECT_FOLLOW_RELATIONSHIPS.FOLLOWER_ID.eq(requesterId),
-                        PROJECT_FOLLOW_RELATIONSHIPS.PROJECT_ID.eq(POSTS.PROJECT_ID))));
+                        PROJECT_FOLLOW_RELATIONSHIPS.PROJECT_ID.eq(POSTS.PROJECT_ID))))
+        .or(
+            DSL.exists(
+                dsl.selectOne()
+                    .from(POST_TAGS)
+                    .join(TAG_FOLLOW_RELATIONSHIPS)
+                    .on(TAG_FOLLOW_RELATIONSHIPS.TAG_ID.eq(POST_TAGS.TAG_ID))
+                    .join(TAGS)
+                    .on(TAGS.ID.eq(POST_TAGS.TAG_ID))
+                    .where(
+                        POST_TAGS.POST_ID.eq(POSTS.ID),
+                        TAG_FOLLOW_RELATIONSHIPS.FOLLOWER_ID.eq(requesterId),
+                        TAGS.PROJECT_ID.isNull())));
   }
 
   public Condition trendingCondition() {
@@ -94,5 +111,9 @@ public class PostRecommendationQueryRepository {
 
   private Condition scopeCondition(@Nullable PostScope scope) {
     return scope == null ? DSL.noCondition() : PostConditions.scope(scope);
+  }
+
+  private Condition postTypeCondition(@Nullable PostType postType) {
+    return postType == null ? DSL.noCondition() : POSTS.POST_TYPE.eq(postType.name());
   }
 }

--- a/apps/server/src/main/java/com/skkil/sync/post/repository/TagRecommendationQueryRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/post/repository/TagRecommendationQueryRepository.java
@@ -2,11 +2,10 @@ package com.skkil.sync.post.repository;
 
 import static com.skkil.sync.jooq.tables.PostTags.POST_TAGS;
 import static com.skkil.sync.jooq.tables.Posts.POSTS;
+import static com.skkil.sync.jooq.tables.Projects.PROJECTS;
 import static com.skkil.sync.jooq.tables.TagFollowRelationships.TAG_FOLLOW_RELATIONSHIPS;
 import static com.skkil.sync.jooq.tables.Tags.TAGS;
 
-import com.skkil.sync.post.model.PostStatus;
-import com.skkil.sync.post.model.PostVisibility;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -36,13 +35,14 @@ public class TagRecommendationQueryRepository {
         .from(POST_TAGS)
         .join(POSTS)
         .on(POSTS.ID.eq(POST_TAGS.POST_ID))
+        .leftJoin(PROJECTS)
+        .on(PROJECTS.ID.eq(POSTS.PROJECT_ID))
         .where(POSTS.CREATED_AT.ge(since))
-        .and(visibleCondition())
-        .and(publicPublishedCondition())
+        .and(PostConditions.feedVisible())
         .and(isGlobalVerifiedTag(POST_TAGS.TAG_ID))
         .andNotExists(alreadyFollowing(userId, POST_TAGS.TAG_ID))
         .groupBy(POST_TAGS.TAG_ID)
-        .orderBy(DSL.count().desc())
+        .orderBy(DSL.count().desc(), POST_TAGS.TAG_ID.desc())
         .limit(limit)
         .fetch(POST_TAGS.TAG_ID);
   }
@@ -53,7 +53,7 @@ public class TagRecommendationQueryRepository {
         .from(TAGS)
         .where(TAGS.PROJECT_ID.isNull(), TAGS.VERIFIED.isTrue())
         .andNotExists(alreadyFollowing(userId, TAGS.ID))
-        .orderBy(TAGS.CREATED_AT.desc())
+        .orderBy(TAGS.CREATED_AT.desc(), TAGS.ID.desc())
         .limit(limit)
         .fetch(TAGS.ID);
   }
@@ -71,13 +71,5 @@ public class TagRecommendationQueryRepository {
         .where(
             TAG_FOLLOW_RELATIONSHIPS.FOLLOWER_ID.eq(userId),
             TAG_FOLLOW_RELATIONSHIPS.TAG_ID.eq(tagId));
-  }
-
-  private Condition visibleCondition() {
-    return POSTS.VISIBILITY.eq(PostVisibility.VISIBLE.name());
-  }
-
-  private Condition publicPublishedCondition() {
-    return POSTS.PROJECT_ID.isNull().and(POSTS.STATUS.eq(PostStatus.PUBLISHED.name()));
   }
 }

--- a/apps/server/src/main/java/com/skkil/sync/user/repository/UserRecommendationQueryRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/user/repository/UserRecommendationQueryRepository.java
@@ -7,6 +7,7 @@ import static com.skkil.sync.jooq.tables.Users.USERS;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.impl.DSL;
 import org.springframework.stereotype.Repository;
@@ -28,7 +29,10 @@ public class UserRecommendationQueryRepository {
         .from(mine)
         .join(other)
         .on(other.PROJECT_ID.eq(mine.PROJECT_ID), other.FOLLOWER_ID.ne(userId))
+        .join(USERS)
+        .on(USERS.ID.eq(other.FOLLOWER_ID))
         .where(mine.FOLLOWER_ID.eq(userId))
+        .and(recommendableUserCondition())
         .andNotExists(
             dsl.selectOne()
                 .from(USER_FOLLOW_RELATIONSHIPS)
@@ -36,7 +40,7 @@ public class UserRecommendationQueryRepository {
                     USER_FOLLOW_RELATIONSHIPS.FOLLOWER_ID.eq(userId),
                     USER_FOLLOW_RELATIONSHIPS.FOLLOWEE_ID.eq(other.FOLLOWER_ID)))
         .groupBy(other.FOLLOWER_ID)
-        .orderBy(DSL.count().desc())
+        .orderBy(DSL.count().desc(), other.FOLLOWER_ID.desc())
         .limit(limit)
         .fetch(other.FOLLOWER_ID);
   }
@@ -47,8 +51,11 @@ public class UserRecommendationQueryRepository {
 
     return dsl.select(USER_FOLLOW_RELATIONSHIPS.FOLLOWEE_ID)
         .from(USER_FOLLOW_RELATIONSHIPS)
+        .join(USERS)
+        .on(USERS.ID.eq(USER_FOLLOW_RELATIONSHIPS.FOLLOWEE_ID))
         .where(USER_FOLLOW_RELATIONSHIPS.CREATED_AT.ge(since))
         .and(USER_FOLLOW_RELATIONSHIPS.FOLLOWEE_ID.ne(userId))
+        .and(recommendableUserCondition())
         .andNotExists(
             dsl.selectOne()
                 .from(mine)
@@ -56,7 +63,7 @@ public class UserRecommendationQueryRepository {
                     mine.FOLLOWER_ID.eq(userId),
                     mine.FOLLOWEE_ID.eq(USER_FOLLOW_RELATIONSHIPS.FOLLOWEE_ID)))
         .groupBy(USER_FOLLOW_RELATIONSHIPS.FOLLOWEE_ID)
-        .orderBy(DSL.count().desc())
+        .orderBy(DSL.count().desc(), USER_FOLLOW_RELATIONSHIPS.FOLLOWEE_ID.desc())
         .limit(limit)
         .fetch(USER_FOLLOW_RELATIONSHIPS.FOLLOWEE_ID);
   }
@@ -65,15 +72,19 @@ public class UserRecommendationQueryRepository {
   public List<Long> findRecentlyJoinedCandidateIds(Long userId, int limit) {
     return dsl.select(USERS.ID)
         .from(USERS)
-        .where(USERS.ID.ne(userId), USERS.DELETED_AT.isNull())
+        .where(USERS.ID.ne(userId), recommendableUserCondition())
         .andNotExists(
             dsl.selectOne()
                 .from(USER_FOLLOW_RELATIONSHIPS)
                 .where(
                     USER_FOLLOW_RELATIONSHIPS.FOLLOWER_ID.eq(userId),
                     USER_FOLLOW_RELATIONSHIPS.FOLLOWEE_ID.eq(USERS.ID)))
-        .orderBy(USERS.CREATED_AT.desc())
+        .orderBy(USERS.CREATED_AT.desc(), USERS.ID.desc())
         .limit(limit)
         .fetch(USERS.ID);
+  }
+
+  private Condition recommendableUserCondition() {
+    return USERS.DELETED_AT.isNull().and(USERS.IS_ONBOARDED.isTrue()).and(USERS.HANDLE.isNotNull());
   }
 }

--- a/apps/server/src/test/java/com/skkil/sync/post/controller/PostRecommendationControllerTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/post/controller/PostRecommendationControllerTests.java
@@ -24,6 +24,7 @@ import com.skkil.sync.post.dto.data.PostRecommendationContext;
 import com.skkil.sync.post.dto.response.PaginatedGetPostsResponse;
 import com.skkil.sync.post.model.PostRecommendationType;
 import com.skkil.sync.post.model.PostScope;
+import com.skkil.sync.post.model.PostType;
 import com.skkil.sync.post.service.PostRecommendationService;
 import com.skkil.sync.post.snippets.PaginatedGetPostsResponseSnippets;
 import java.util.function.Function;
@@ -62,7 +63,7 @@ class PostRecommendationControllerTests {
         CursorPaginationRequestSnippets.getCursorPaginationRequestQueryParams();
 
     when(postRecommendationService.getRecommendations(
-            eq(new PostRecommendationContext(user.userId(), null)), isNull(), any()))
+            eq(new PostRecommendationContext(user.userId(), null, null)), isNull(), any()))
         .thenReturn(response);
 
     mockMvc
@@ -86,6 +87,9 @@ class PostRecommendationControllerTests {
                             .description(
                                 "게시글 범위 필터. PUBLIC 은 개인 게시글만, WORKSPACE 는 프로젝트 게시글만 조회한다. "
                                     + "생략하면 두 종류를 모두 포함한다.")
+                            .optional(),
+                        parameterWithName("postType")
+                            .description("게시글 형태 필터. SHORT, LONG, QUESTION 중 하나를 사용한다.")
                             .optional()),
                 PaginatedGetPostsResponseSnippets.getPostsResponseFields()));
   }
@@ -99,7 +103,7 @@ class PostRecommendationControllerTests {
         PaginatedGetPostsResponseSnippets.getPaginatedGetPostsResponse();
 
     when(postRecommendationService.getRecommendations(
-            eq(new PostRecommendationContext(user.userId(), null)),
+            eq(new PostRecommendationContext(user.userId(), null, null)),
             eq(PostRecommendationType.TRENDING),
             any()))
         .thenReturn(response);
@@ -118,7 +122,7 @@ class PostRecommendationControllerTests {
         PaginatedGetPostsResponseSnippets.getPaginatedGetPostsResponse();
 
     when(postRecommendationService.getRecommendations(
-            eq(new PostRecommendationContext(user.userId(), PostScope.WORKSPACE)),
+            eq(new PostRecommendationContext(user.userId(), PostScope.WORKSPACE, null)),
             eq(PostRecommendationType.TRENDING),
             any()))
         .thenReturn(response);
@@ -128,6 +132,28 @@ class PostRecommendationControllerTests {
             get("/posts/recommendations")
                 .queryParam("type", "TRENDING")
                 .queryParam("scope", "WORKSPACE"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("[getRecommendations] postType 파라미터가 주어지면 해당 형태의 게시글만 조회한다")
+  @WithAuthenticatedUser
+  void getRecommendations_withPostType_shouldFilterByPostType() throws Exception {
+    AuthenticatedUser user = WithAuthenticatedUserSecurityContextFactory.getAuthenticatedUser();
+    PaginatedGetPostsResponse response =
+        PaginatedGetPostsResponseSnippets.getPaginatedGetPostsResponse();
+
+    when(postRecommendationService.getRecommendations(
+            eq(new PostRecommendationContext(user.userId(), null, PostType.QUESTION)),
+            eq(PostRecommendationType.FOLLOWING),
+            any()))
+        .thenReturn(response);
+
+    mockMvc
+        .perform(
+            get("/posts/recommendations")
+                .queryParam("type", "FOLLOWING")
+                .queryParam("postType", "QUESTION"))
         .andExpect(status().isOk());
   }
 

--- a/apps/server/src/test/java/com/skkil/sync/post/repository/PostRecommendationQueryRepositoryTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/post/repository/PostRecommendationQueryRepositoryTests.java
@@ -10,12 +10,19 @@ import com.skkil.sync.post.dto.data.PostRecommendationContext;
 import com.skkil.sync.post.model.Post;
 import com.skkil.sync.post.model.PostScope;
 import com.skkil.sync.post.model.PostStatus;
+import com.skkil.sync.post.model.PostTag;
 import com.skkil.sync.post.model.PostType;
+import com.skkil.sync.post.model.Tag;
+import com.skkil.sync.post.model.TagFollowRelationship;
 import com.skkil.sync.project.model.Project;
+import com.skkil.sync.project.model.ProjectFollowRelationship;
 import com.skkil.sync.project.model.Teammate;
+import com.skkil.sync.project.repository.ProjectFollowRelationshipRepository;
 import com.skkil.sync.project.repository.ProjectRepository;
 import com.skkil.sync.project.repository.TeammateRepository;
 import com.skkil.sync.user.model.User;
+import com.skkil.sync.user.model.UserFollowRelationship;
+import com.skkil.sync.user.repository.UserFollowRelationshipRepository;
 import com.skkil.sync.user.repository.UserRepository;
 import java.util.List;
 import org.jooq.impl.DSL;
@@ -36,11 +43,159 @@ class PostRecommendationQueryRepositoryTests {
 
   @Autowired private PostRepository postRepository;
 
+  @Autowired private PostTagRepository postTagRepository;
+
+  @Autowired private TagRepository tagRepository;
+
+  @Autowired private TagFollowRelationshipRepository tagFollowRelationshipRepository;
+
   @Autowired private ProjectRepository projectRepository;
+
+  @Autowired private ProjectFollowRelationshipRepository projectFollowRelationshipRepository;
 
   @Autowired private TeammateRepository teammateRepository;
 
   @Autowired private UserRepository userRepository;
+
+  @Autowired private UserFollowRelationshipRepository userFollowRelationshipRepository;
+
+  @Test
+  @DisplayName("[팔로잉 게시글] 사용자·프로젝트·전역 태그로 팔로우한 게시글을 중복 없이 조회한다")
+  void getFollowingCandidates_includesUserProjectAndGlobalTagMatchesWithoutDuplicates() {
+    User requester = saveUser("following-requester");
+    User followedAuthor = saveUser("following-author");
+    User unrelatedAuthor = saveUser("following-unrelated-author");
+    Project followedProject = saveProject("following-project", true);
+    Tag followedTag = saveTag("following-global-tag", null);
+
+    userFollowRelationshipRepository.saveAndFlush(
+        UserFollowRelationship.builder().follower(requester).followee(followedAuthor).build());
+    projectFollowRelationshipRepository.saveAndFlush(
+        ProjectFollowRelationship.builder().follower(requester).project(followedProject).build());
+    followTag(requester, followedTag);
+
+    Post userPost = savePost("following-user-post", followedAuthor, null);
+    Post projectPost = savePost("following-project-post", unrelatedAuthor, followedProject);
+    Post tagPost = savePost("following-tag-post", unrelatedAuthor, null);
+    addTag(tagPost, followedTag);
+
+    Post allConditionsPost =
+        savePost("following-all-conditions-post", followedAuthor, followedProject);
+    addTag(allConditionsPost, followedTag);
+
+    Post unrelatedPost = savePost("following-unrelated-post", unrelatedAuthor, null);
+
+    List<PostRecommendationCandidate> candidates =
+        getFollowingCandidates(new PostRecommendationContext(requester.getId(), null, null));
+
+    assertThat(candidates)
+        .extracting(PostRecommendationCandidate::id)
+        .containsExactlyInAnyOrder(
+            userPost.getId(), projectPost.getId(), tagPost.getId(), allConditionsPost.getId())
+        .doesNotContain(unrelatedPost.getId());
+  }
+
+  @Test
+  @DisplayName("[팔로잉 게시글] 프로젝트 전용 태그 팔로우 데이터는 후보 조건으로 사용하지 않는다")
+  void getFollowingCandidates_ignoresProjectTagFollowRelationship() {
+    User requester = saveUser("project-tag-requester");
+    User author = saveUser("project-tag-author");
+    Project project = saveProject("project-tag-project", true);
+    Tag projectTag = saveTag("project-only-tag", project);
+    followTag(requester, projectTag);
+
+    Post post = savePost("project-tag-post", author, project);
+    addTag(post, projectTag);
+
+    List<PostRecommendationCandidate> candidates =
+        getFollowingCandidates(new PostRecommendationContext(requester.getId(), null, null));
+
+    assertThat(candidates).extracting(PostRecommendationCandidate::id).doesNotContain(post.getId());
+  }
+
+  @Test
+  @DisplayName("[팔로잉 게시글] 팔로우 태그가 같아도 비공개 프로젝트 게시글은 팀원에게만 노출한다")
+  void getFollowingCandidates_privateProjectTagPostRequiresMembership() {
+    User author = saveUser("private-tag-author");
+    User teammate = saveUser("private-tag-teammate");
+    User outsider = saveUser("private-tag-outsider");
+    Project privateProject = saveProject("private-tag-project", false);
+    Tag followedTag = saveTag("private-project-global-tag", null);
+
+    teammateRepository.saveAndFlush(Teammate.owner(privateProject, author));
+    teammateRepository.saveAndFlush(Teammate.member(privateProject, teammate));
+    followTag(teammate, followedTag);
+    followTag(outsider, followedTag);
+
+    Post privatePost = savePost("private-tag-post", author, privateProject);
+    addTag(privatePost, followedTag);
+
+    List<PostRecommendationCandidate> teammateCandidates =
+        getFollowingCandidates(new PostRecommendationContext(teammate.getId(), null, null));
+    List<PostRecommendationCandidate> outsiderCandidates =
+        getFollowingCandidates(new PostRecommendationContext(outsider.getId(), null, null));
+
+    assertThat(teammateCandidates)
+        .extracting(PostRecommendationCandidate::id)
+        .containsExactly(privatePost.getId());
+    assertThat(outsiderCandidates)
+        .extracting(PostRecommendationCandidate::id)
+        .doesNotContain(privatePost.getId());
+  }
+
+  @Test
+  @DisplayName("[팔로잉 게시글] scope 필터로 개인 게시글과 프로젝트 게시글을 구분한다")
+  void getFollowingCandidates_filtersByScope() {
+    User requester = saveUser("following-scope-requester");
+    User author = saveUser("following-scope-author");
+    Project project = saveProject("following-scope-project", true);
+    Tag followedTag = saveTag("following-scope-tag", null);
+    followTag(requester, followedTag);
+
+    Post personalPost = savePost("following-scope-personal", author, null);
+    Post projectPost = savePost("following-scope-workspace", author, project);
+    addTag(personalPost, followedTag);
+    addTag(projectPost, followedTag);
+
+    List<PostRecommendationCandidate> personalCandidates =
+        getFollowingCandidates(
+            new PostRecommendationContext(requester.getId(), PostScope.PUBLIC, null));
+    List<PostRecommendationCandidate> projectCandidates =
+        getFollowingCandidates(
+            new PostRecommendationContext(requester.getId(), PostScope.WORKSPACE, null));
+
+    assertThat(personalCandidates)
+        .extracting(PostRecommendationCandidate::id)
+        .containsExactly(personalPost.getId());
+    assertThat(projectCandidates)
+        .extracting(PostRecommendationCandidate::id)
+        .containsExactly(projectPost.getId());
+  }
+
+  @Test
+  @DisplayName("[팔로잉 게시글] postType 필터와 일치하는 형태의 게시글만 조회한다")
+  void getFollowingCandidates_filtersByPostType() {
+    User requester = saveUser("following-type-requester");
+    User author = saveUser("following-type-author");
+    Tag followedTag = saveTag("following-type-tag", null);
+    followTag(requester, followedTag);
+
+    Post shortPost = savePost("following-short-post", author, null, PostType.SHORT);
+    Post longPost = savePost("following-long-post", author, null, PostType.LONG);
+    Post questionPost = savePost("following-question-post", author, null, PostType.QUESTION);
+    addTag(shortPost, followedTag);
+    addTag(longPost, followedTag);
+    addTag(questionPost, followedTag);
+
+    List<PostRecommendationCandidate> candidates =
+        getFollowingCandidates(
+            new PostRecommendationContext(requester.getId(), null, PostType.QUESTION));
+
+    assertThat(candidates)
+        .extracting(PostRecommendationCandidate::id)
+        .containsExactly(questionPost.getId())
+        .doesNotContain(shortPost.getId(), longPost.getId());
+  }
 
   @Test
   @DisplayName("[인기 게시글] 요청자가 팀원이어도 비공개 프로젝트 게시글은 탐색 후보에서 제외한다")
@@ -55,7 +210,7 @@ class PostRecommendationQueryRepositoryTests {
     Post personalPost = savePost("trending-personal-post", author, null);
 
     List<PostRecommendationCandidate> candidates =
-        getDiscoveryCandidates(new PostRecommendationContext(author.getId(), null));
+        getDiscoveryCandidates(new PostRecommendationContext(author.getId(), null, null));
 
     assertThat(candidates)
         .extracting(PostRecommendationCandidate::id)
@@ -76,7 +231,8 @@ class PostRecommendationQueryRepositoryTests {
     Post personalPost = savePost("workspace-trending-personal-post", author, null);
 
     List<PostRecommendationCandidate> candidates =
-        getDiscoveryCandidates(new PostRecommendationContext(author.getId(), PostScope.WORKSPACE));
+        getDiscoveryCandidates(
+            new PostRecommendationContext(author.getId(), PostScope.WORKSPACE, null));
 
     assertThat(candidates)
         .extracting(PostRecommendationCandidate::id)
@@ -91,6 +247,14 @@ class PostRecommendationQueryRepositoryTests {
         .fetch(DSL.noCondition(), List.of(POSTS.LIKE_COUNT.desc(), POSTS.ID.desc()), 10);
   }
 
+  private List<PostRecommendationCandidate> getFollowingCandidates(
+      PostRecommendationContext context) {
+    return postRecommendationQueryRepository
+        .getCandidates(
+            postRecommendationQueryRepository.followingCondition(context.requesterId()), context)
+        .fetch(DSL.noCondition(), List.of(POSTS.CREATED_AT.desc(), POSTS.ID.desc()), 50);
+  }
+
   private User saveUser(String key) {
     return userRepository.saveAndFlush(
         User.builder().email(key + "@example.com").fullName("사용자").build());
@@ -102,17 +266,35 @@ class PostRecommendationQueryRepositoryTests {
   }
 
   private Post savePost(String slug, User author, @Nullable Project project) {
+    return savePost(slug, author, project, PostType.SHORT);
+  }
+
+  private Post savePost(String slug, User author, @Nullable Project project, PostType postType) {
     Post post =
         Post.builder()
             .slug(slug)
             .author(author)
             .project(project)
-            .type(PostType.SHORT)
+            .title(postType == PostType.SHORT ? null : "제목")
+            .type(postType)
             .status(PostStatus.PUBLISHED)
             .content("본문")
             .build();
     post.updateContent("본문", "본문", 0);
 
     return postRepository.saveAndFlush(post);
+  }
+
+  private Tag saveTag(String name, @Nullable Project project) {
+    return tagRepository.saveAndFlush(Tag.builder().name(name).project(project).build());
+  }
+
+  private void addTag(Post post, Tag tag) {
+    postTagRepository.saveAndFlush(PostTag.builder().post(post).tag(tag).build());
+  }
+
+  private void followTag(User follower, Tag tag) {
+    tagFollowRelationshipRepository.saveAndFlush(
+        TagFollowRelationship.builder().follower(follower).tag(tag).build());
   }
 }

--- a/apps/server/src/test/java/com/skkil/sync/post/repository/TagRecommendationQueryRepositoryTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/post/repository/TagRecommendationQueryRepositoryTests.java
@@ -1,0 +1,171 @@
+package com.skkil.sync.post.repository;
+
+import static com.skkil.sync.jooq.tables.Posts.POSTS;
+import static com.skkil.sync.jooq.tables.Tags.TAGS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.skkil.sync.common.config.TestcontainersConfig;
+import com.skkil.sync.config.JpaConfig;
+import com.skkil.sync.post.model.Post;
+import com.skkil.sync.post.model.PostStatus;
+import com.skkil.sync.post.model.PostTag;
+import com.skkil.sync.post.model.PostType;
+import com.skkil.sync.post.model.Tag;
+import com.skkil.sync.post.model.TagFollowRelationship;
+import com.skkil.sync.project.model.Project;
+import com.skkil.sync.project.repository.ProjectRepository;
+import com.skkil.sync.user.model.User;
+import com.skkil.sync.user.repository.UserRepository;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.jooq.DSLContext;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({TestcontainersConfig.class, JpaConfig.class, TagRecommendationQueryRepository.class})
+class TagRecommendationQueryRepositoryTests {
+
+  @Autowired private TagRecommendationQueryRepository tagRecommendationQueryRepository;
+
+  @Autowired private PostRepository postRepository;
+
+  @Autowired private PostTagRepository postTagRepository;
+
+  @Autowired private TagRepository tagRepository;
+
+  @Autowired private TagFollowRelationshipRepository tagFollowRelationshipRepository;
+
+  @Autowired private ProjectRepository projectRepository;
+
+  @Autowired private UserRepository userRepository;
+
+  @Autowired private DSLContext dsl;
+
+  @Test
+  @DisplayName("[인기 태그 추천] 개인 및 공개 프로젝트 게시글만 집계하고 동률이면 ID 역순으로 반환한다")
+  void findTrendingCandidateIds_countsOnlyPublicFeedPostsInStableOrder() {
+    User requester = saveUser("tag-requester");
+    User author = saveUser("tag-author");
+    Project publicProject = saveProject("public-tag-project", true);
+    Project privateProject = saveProject("private-tag-project", false);
+
+    Tag personalTag = saveTag("personal-tag", null, true);
+    Tag publicProjectPostTag = saveTag("public-project-post-tag", null, true);
+    Tag privateProjectPostTag = saveTag("private-project-post-tag", null, true);
+    Tag draftPostTag = saveTag("draft-post-tag", null, true);
+    Tag hiddenPostTag = saveTag("hidden-post-tag", null, true);
+    Tag oldPostTag = saveTag("old-post-tag", null, true);
+    Tag followedTag = saveTag("followed-tag", null, true);
+    Tag unverifiedTag = saveTag("unverified-tag", null, false);
+    Tag projectTag = saveTag("project-tag", publicProject, true);
+
+    attachTag(savePost("personal-tag-post", author, null, PostStatus.PUBLISHED), personalTag);
+    attachTag(
+        savePost("public-project-tag-post", author, publicProject, PostStatus.PUBLISHED),
+        publicProjectPostTag);
+    attachTag(
+        savePost("private-project-tag-post", author, privateProject, PostStatus.PUBLISHED),
+        privateProjectPostTag);
+    attachTag(savePost("draft-tag-post", author, null, PostStatus.DRAFT), draftPostTag);
+
+    Post hiddenPost = savePost("hidden-tag-post", author, null, PostStatus.PUBLISHED);
+    hiddenPost.hide(author, "추천 집계 제외");
+    postRepository.saveAndFlush(hiddenPost);
+    attachTag(hiddenPost, hiddenPostTag);
+
+    Post oldPost = savePost("old-tag-post", author, null, PostStatus.PUBLISHED);
+    attachTag(oldPost, oldPostTag);
+    markPostAsOld(oldPost);
+
+    attachTag(savePost("followed-tag-post", author, null, PostStatus.PUBLISHED), followedTag);
+    tagFollowRelationshipRepository.saveAndFlush(
+        TagFollowRelationship.builder().follower(requester).tag(followedTag).build());
+
+    attachTag(savePost("unverified-tag-post", author, null, PostStatus.PUBLISHED), unverifiedTag);
+    attachTag(
+        savePost("project-scoped-tag-post", author, publicProject, PostStatus.PUBLISHED),
+        projectTag);
+
+    assertThat(tagRecommendationQueryRepository.findTrendingCandidateIds(requester.getId(), 20))
+        .containsExactly(publicProjectPostTag.getId(), personalTag.getId());
+  }
+
+  @Test
+  @DisplayName("[최근 태그 추천] 검증된 전역 태그 중 아직 팔로우하지 않은 태그를 안정적으로 반환한다")
+  void findRecentlyCreatedCandidateIds_returnsOnlyUnfollowedGlobalVerifiedTagsInStableOrder() {
+    User requester = saveUser("recent-tag-requester");
+    Project project = saveProject("recent-tag-project", true);
+    Tag first = saveTag("recent-first", null, true);
+    Tag second = saveTag("recent-second", null, true);
+    Tag alreadyFollowing = saveTag("recent-following", null, true);
+    Tag unverified = saveTag("recent-unverified", null, false);
+    Tag projectTag = saveTag("recent-project-tag", project, true);
+
+    tagFollowRelationshipRepository.saveAndFlush(
+        TagFollowRelationship.builder().follower(requester).tag(alreadyFollowing).build());
+    setSameCreatedAt(List.of(first, second, alreadyFollowing, unverified, projectTag));
+
+    assertThat(
+            tagRecommendationQueryRepository.findRecentlyCreatedCandidateIds(requester.getId(), 20))
+        .containsExactly(second.getId(), first.getId());
+  }
+
+  private User saveUser(String key) {
+    return userRepository.saveAndFlush(
+        User.builder().email(key + "@example.com").fullName("태그 추천 사용자").build());
+  }
+
+  private Project saveProject(String handle, boolean isPublic) {
+    return projectRepository.saveAndFlush(
+        Project.builder().handle(handle).name(handle).isPublic(isPublic).build());
+  }
+
+  private Tag saveTag(String name, @Nullable Project project, boolean verified) {
+    Tag tag = Tag.builder().name(name).description(name).project(project).build();
+    if (verified) {
+      tag.verify();
+    }
+    return tagRepository.saveAndFlush(tag);
+  }
+
+  private Post savePost(String slug, User author, @Nullable Project project, PostStatus status) {
+    Post post =
+        Post.builder()
+            .slug(slug)
+            .author(author)
+            .project(project)
+            .type(PostType.SHORT)
+            .status(status)
+            .content("본문")
+            .build();
+    post.updateContent("본문", "본문", 0);
+    return postRepository.saveAndFlush(post);
+  }
+
+  private void attachTag(Post post, Tag tag) {
+    postTagRepository.saveAndFlush(PostTag.builder().post(post).tag(tag).build());
+  }
+
+  private void markPostAsOld(Post post) {
+    dsl.update(POSTS)
+        .set(POSTS.CREATED_AT, OffsetDateTime.now(ZoneOffset.UTC).minusDays(8))
+        .where(POSTS.ID.eq(post.getId()))
+        .execute();
+  }
+
+  private void setSameCreatedAt(List<Tag> tags) {
+    OffsetDateTime createdAt = OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(1);
+    dsl.update(TAGS)
+        .set(TAGS.CREATED_AT, createdAt)
+        .where(TAGS.ID.in(tags.stream().map(Tag::getId).toList()))
+        .execute();
+  }
+}

--- a/apps/server/src/test/java/com/skkil/sync/user/repository/UserRecommendationQueryRepositoryTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/user/repository/UserRecommendationQueryRepositoryTests.java
@@ -1,0 +1,162 @@
+package com.skkil.sync.user.repository;
+
+import static com.skkil.sync.jooq.tables.Users.USERS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.skkil.sync.common.config.TestcontainersConfig;
+import com.skkil.sync.config.JpaConfig;
+import com.skkil.sync.project.model.Project;
+import com.skkil.sync.project.model.ProjectFollowRelationship;
+import com.skkil.sync.project.repository.ProjectFollowRelationshipRepository;
+import com.skkil.sync.project.repository.ProjectRepository;
+import com.skkil.sync.user.model.User;
+import com.skkil.sync.user.model.UserFollowRelationship;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({TestcontainersConfig.class, JpaConfig.class, UserRecommendationQueryRepository.class})
+class UserRecommendationQueryRepositoryTests {
+
+  @Autowired private UserRecommendationQueryRepository userRecommendationQueryRepository;
+
+  @Autowired private UserRepository userRepository;
+
+  @Autowired private UserFollowRelationshipRepository userFollowRelationshipRepository;
+
+  @Autowired private ProjectRepository projectRepository;
+
+  @Autowired private ProjectFollowRelationshipRepository projectFollowRelationshipRepository;
+
+  @Autowired private DSLContext dsl;
+
+  @Test
+  @DisplayName("[프로젝트 중복 추천] 유효한 사용자만 같은 프로젝트 팔로우 수와 ID 순으로 반환한다")
+  void findProjectOverlapCandidateIds_returnsOnlyRecommendableUsersInStableOrder() {
+    User requester = saveOnboardedUser("overlap-requester");
+    User first = saveOnboardedUser("overlap-first");
+    User second = saveOnboardedUser("overlap-second");
+    User notOnboarded = saveNotOnboardedUser("overlap-not-onboarded");
+    User missingHandle = saveUserWithoutHandle("missing-handle-overlap");
+    User deleted = saveOnboardedUser("overlap-deleted");
+    Project project = saveProject("overlap-project");
+
+    followProject(requester, project);
+    followProject(first, project);
+    followProject(second, project);
+    followProject(notOnboarded, project);
+    followProject(missingHandle, project);
+    followProject(deleted, project);
+    markOnboardedWithoutHandle(missingHandle);
+    markDeleted(deleted);
+
+    assertThat(
+            userRecommendationQueryRepository.findProjectOverlapCandidateIds(requester.getId(), 20))
+        .containsExactly(second.getId(), first.getId());
+  }
+
+  @Test
+  @DisplayName("[인기 사용자 추천] 유효한 사용자만 최근 팔로우 수와 ID 순으로 반환한다")
+  void findTrendingCandidateIds_returnsOnlyRecommendableUsersInStableOrder() {
+    User requester = saveOnboardedUser("trending-requester");
+    User follower = saveOnboardedUser("trending-follower");
+    User first = saveOnboardedUser("trending-first");
+    User second = saveOnboardedUser("trending-second");
+    User notOnboarded = saveNotOnboardedUser("trending-not-onboarded");
+    User missingHandle = saveUserWithoutHandle("missing-handle-trending");
+    User deleted = saveOnboardedUser("trending-deleted");
+
+    followUser(follower, first);
+    followUser(follower, second);
+    followUser(follower, notOnboarded);
+    followUser(follower, missingHandle);
+    followUser(follower, deleted);
+    markOnboardedWithoutHandle(missingHandle);
+    markDeleted(deleted);
+
+    assertThat(userRecommendationQueryRepository.findTrendingCandidateIds(requester.getId(), 20))
+        .containsExactly(second.getId(), first.getId());
+  }
+
+  @Test
+  @DisplayName("[최근 가입 추천] 유효하고 아직 팔로우하지 않은 사용자를 생성 시각과 ID 순으로 반환한다")
+  void findRecentlyJoinedCandidateIds_returnsOnlyUnfollowedRecommendableUsersInStableOrder() {
+    User requester = saveOnboardedUser("recent-requester");
+    User first = saveOnboardedUser("recent-first");
+    User second = saveOnboardedUser("recent-second");
+    User alreadyFollowing = saveOnboardedUser("recent-already-following");
+    User notOnboarded = saveNotOnboardedUser("recent-not-onboarded");
+    User missingHandle = saveUserWithoutHandle("missing-handle-recent");
+    User deleted = saveOnboardedUser("recent-deleted");
+
+    followUser(requester, alreadyFollowing);
+    markOnboardedWithoutHandle(missingHandle);
+    markDeleted(deleted);
+    setSameCreatedAt(
+        List.of(first, second, alreadyFollowing, notOnboarded, missingHandle, deleted));
+
+    assertThat(
+            userRecommendationQueryRepository.findRecentlyJoinedCandidateIds(requester.getId(), 20))
+        .containsExactly(second.getId(), first.getId());
+  }
+
+  private User saveOnboardedUser(String key) {
+    User user = saveNotOnboardedUser(key);
+    user.onboard();
+    return userRepository.saveAndFlush(user);
+  }
+
+  private User saveNotOnboardedUser(String key) {
+    User user = User.builder().email(key + "@example.com").fullName("추천 사용자").build();
+    user.updateHandle(key);
+    return userRepository.saveAndFlush(user);
+  }
+
+  private User saveUserWithoutHandle(String key) {
+    return userRepository.saveAndFlush(
+        User.builder().email(key + "@example.com").fullName("추천 사용자").build());
+  }
+
+  private Project saveProject(String handle) {
+    return projectRepository.saveAndFlush(
+        Project.builder().handle(handle).name(handle).isPublic(true).build());
+  }
+
+  private void followProject(User follower, Project project) {
+    projectFollowRelationshipRepository.saveAndFlush(
+        ProjectFollowRelationship.builder().follower(follower).project(project).build());
+  }
+
+  private void followUser(User follower, User followee) {
+    userFollowRelationshipRepository.saveAndFlush(
+        UserFollowRelationship.builder().follower(follower).followee(followee).build());
+  }
+
+  private void markOnboardedWithoutHandle(User user) {
+    dsl.update(USERS).set(USERS.IS_ONBOARDED, true).where(USERS.ID.eq(user.getId())).execute();
+  }
+
+  private void markDeleted(User user) {
+    dsl.update(USERS)
+        .set(USERS.DELETED_AT, OffsetDateTime.now(ZoneOffset.UTC))
+        .where(USERS.ID.eq(user.getId()))
+        .execute();
+  }
+
+  private void setSameCreatedAt(List<User> users) {
+    OffsetDateTime createdAt = OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(1);
+    dsl.update(USERS)
+        .set(USERS.CREATED_AT, createdAt)
+        .where(USERS.ID.in(users.stream().map(User::getId).toList()))
+        .execute();
+  }
+}

--- a/apps/web/public/locales/ko.json
+++ b/apps/web/public/locales/ko.json
@@ -12,11 +12,29 @@
         "title": "팔로우할 사람 추천",
         "explore": "탐색",
         "follow": "팔로우",
-        "following": "팔로잉"
+        "following": "팔로잉",
+        "empty": "지금 추천할 사용자가 없어요.",
+        "error": {
+          "description": "추천 사용자를 불러오지 못했어요.",
+          "retry": "다시 시도"
+        }
       },
       "feed": {
         "title": "홈",
         "description": "팔로우하는 사람, 프로젝트, 태그의 소식입니다.",
+        "empty": {
+          "title": "아직 표시할 소식이 없어요",
+          "description": "관심 있는 사용자, 프로젝트, 태그를 팔로우하면 여기에 새 글이 모여요."
+        },
+        "error": {
+          "title": "피드를 불러오지 못했어요",
+          "description": "잠시 후 다시 시도해 주세요.",
+          "retry": "다시 시도"
+        },
+        "pagination-error": {
+          "description": "다음 게시글을 불러오지 못했어요.",
+          "retry": "다시 시도"
+        },
         "tabs": {
           "all": "전체",
           "shorts": "TIL",
@@ -29,7 +47,15 @@
         "explore": "탐색",
         "post-count": "게시물 {count}개",
         "follow": "팔로우",
-        "following": "팔로잉"
+        "following": "팔로잉",
+        "empty": "표시할 인기 태그가 없어요.",
+        "error": {
+          "description": "인기 태그를 불러오지 못했어요.",
+          "retry": "다시 시도"
+        },
+        "messages": {
+          "follow-error": "태그 팔로우 상태를 변경하지 못했어요."
+        }
       }
     },
     "explore": {

--- a/apps/web/src/api/__generated__/types/GetPostRecommendationsParams.ts
+++ b/apps/web/src/api/__generated__/types/GetPostRecommendationsParams.ts
@@ -30,4 +30,8 @@ export type GetPostRecommendationsParams = {
    * 게시글 범위 필터. PUBLIC 은 개인 게시글만, WORKSPACE 는 프로젝트 게시글만 조회한다. 생략하면 두 종류를 모두 포함한다.
    */
   scope?: string;
+  /**
+   * 게시글 형태 필터. SHORT, LONG, QUESTION 중 하나를 사용한다.
+   */
+  postType?: string;
 };

--- a/apps/web/src/app/(app)/(home)/_components/DiscoverCard.tsx
+++ b/apps/web/src/app/(app)/(home)/_components/DiscoverCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
+import { useState } from 'react';
 
 import { useGetUserRecommendations } from '@/api/__generated__/user/user';
 import { ProfileHoverCard } from '@/components/feature/profile/ProfileHoverCard';
@@ -16,10 +17,29 @@ const MAX_DISCOVER_USERS = 4;
 export default function DiscoverCard() {
   const t = useTranslations('pages.home.discover');
   const followedUserIds = useFollowedRecommendedUserIds();
-  const { data, isPending } = useGetUserRecommendations();
-  const { mutate: followUser, isPending: isFollowPending } = useFollowUser();
+  const { data, isPending, isError, isFetching, refetch } =
+    useGetUserRecommendations();
+  const { mutate: followUser } = useFollowUser();
+  const [pendingUserIds, setPendingUserIds] = useState<Set<string>>(new Set());
 
   const users = (data?.data.users ?? []).slice(0, MAX_DISCOVER_USERS);
+  const hasInitialError = isError && !data;
+
+  const follow = (userId: string) => {
+    setPendingUserIds((previous) => new Set(previous).add(userId));
+    followUser(
+      { followeeId: userId },
+      {
+        onSettled: () => {
+          setPendingUserIds((previous) => {
+            const next = new Set(previous);
+            next.delete(userId);
+            return next;
+          });
+        },
+      },
+    );
+  };
 
   return (
     <div className="space-y-4 rounded-xl border bg-card p-6">
@@ -28,49 +48,69 @@ export default function DiscoverCard() {
       </div>
 
       <div className="space-y-3">
-        {isPending
-          ? Array.from({ length: MAX_DISCOVER_USERS }).map((_, index) => (
-              <div key={index} className="flex items-center gap-2">
-                <Skeleton className="size-9 rounded-full" />
-                <div className="flex-1 space-y-1">
-                  <Skeleton className="h-3 w-20" />
-                  <Skeleton className="h-3 w-14" />
-                </div>
-                <Skeleton className="h-7 w-16" />
+        {isPending ? (
+          Array.from({ length: MAX_DISCOVER_USERS }).map((_, index) => (
+            <div key={index} className="flex items-center gap-2">
+              <Skeleton className="size-9 rounded-full" />
+              <div className="flex-1 space-y-1">
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-3 w-14" />
               </div>
-            ))
-          : users.map((user) => {
-              const isFollowing = followedUserIds.includes(user.userId);
+              <Skeleton className="h-7 w-16" />
+            </div>
+          ))
+        ) : hasInitialError ? (
+          <div role="alert" className="flex flex-col items-start gap-2 py-2">
+            <p className="text-muted-foreground text-sm">
+              {t('error.description')}
+            </p>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={isFetching}
+              onClick={() => void refetch()}
+            >
+              {t('error.retry')}
+            </Button>
+          </div>
+        ) : users.length === 0 ? (
+          <p className="text-muted-foreground py-2 text-sm">{t('empty')}</p>
+        ) : (
+          users.map((user) => {
+            const isFollowing = followedUserIds.includes(user.userId);
 
-              return (
-                <div key={user.userId} className="flex items-center gap-2">
-                  <ProfileHoverCard
-                    handle={user.summary.handle}
-                    name={user.summary.name}
-                  />
+            return (
+              <div key={user.userId} className="flex items-center gap-2">
+                <ProfileHoverCard
+                  handle={user.summary.handle}
+                  name={user.summary.name}
+                  imageUrl={user.summary.profileImageUrl ?? undefined}
+                />
 
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-medium">
-                      {user.summary.name}
-                    </p>
-                    {/* TODO: no bio/role field on user recommendations yet
-                    — placeholder subtitle until that exists. */}
-                    <p className="text-muted-foreground truncate text-xs">
-                      @{user.summary.handle}
-                    </p>
-                  </div>
-
-                  <Button
-                    size="sm"
-                    variant={isFollowing ? 'outline' : 'default'}
-                    disabled={isFollowPending || isFollowing}
-                    onClick={() => followUser({ followeeId: user.userId })}
-                  >
-                    {isFollowing ? t('following') : t('follow')}
-                  </Button>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">
+                    {user.summary.name}
+                  </p>
+                  {/* TODO: 사용자 추천 응답에 소개/역할 필드가 추가되기 전까지
+                    핸들을 보조 문구로 사용한다. */}
+                  <p className="text-muted-foreground truncate text-xs">
+                    @{user.summary.handle}
+                  </p>
                 </div>
-              );
-            })}
+
+                <Button
+                  size="sm"
+                  variant={isFollowing ? 'outline' : 'default'}
+                  isPending={pendingUserIds.has(user.userId)}
+                  disabled={isFollowing}
+                  onClick={() => follow(user.userId)}
+                >
+                  {isFollowing ? t('following') : t('follow')}
+                </Button>
+              </div>
+            );
+          })
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/app/(app)/(home)/_components/HomeFeed.tsx
+++ b/apps/web/src/app/(app)/(home)/_components/HomeFeed.tsx
@@ -1,70 +1,111 @@
 'use client';
 
+import { WarningCircleIcon } from '@phosphor-icons/react';
 import { useTranslations } from 'next-intl';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { useGetPostRecommendationsInfinite } from '@/api/__generated__/post/post';
-import { PostType } from '@/components/feature/post/types/post';
 import PostList from '@/components/feature/post/viewer/PostList';
 import { toPostSummary } from '@/components/feature/post/viewer/types';
+import { Button } from '@/components/ui/button';
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
-const FEED_PAGE_SIZE = '50';
-
-const FILTERS = [
-  { value: 'all', type: undefined },
-  { value: 'shorts', type: PostType.SHORT },
-  { value: 'articles', type: PostType.LONG },
-  { value: 'questions', type: PostType.QUESTION },
-] as const;
-
-type Filter = (typeof FILTERS)[number]['value'];
+import { type HomeFeedFilter, createHomeFeedParams } from './homeFeed';
 
 export default function HomeFeed() {
-  const t = useTranslations('pages.home.feed.tabs');
-  const [filter, setFilter] = useState<Filter>('all');
+  const t = useTranslations('pages.home.feed');
+  const [filter, setFilter] = useState<HomeFeedFilter>('all');
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } =
-    useGetPostRecommendationsInfinite(
-      {
-        type: 'FOLLOWING',
-        first: FEED_PAGE_SIZE,
-        after: '',
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isError,
+    isFetching,
+    isFetchingNextPage,
+    isFetchNextPageError,
+    isPending,
+    refetch,
+  } = useGetPostRecommendationsInfinite(createHomeFeedParams(filter, '50'), {
+    query: {
+      getNextPageParam: (lastPage) => {
+        const pageInfo = lastPage.data.posts?.pageInfo;
+        return pageInfo?.hasNextPage
+          ? (pageInfo.endCursor ?? undefined)
+          : undefined;
       },
-      {
-        query: {
-          getNextPageParam: (lastPage) => {
-            const pageInfo = lastPage.data.posts?.pageInfo;
-            return pageInfo?.hasNextPage
-              ? (pageInfo.endCursor ?? undefined)
-              : undefined;
-          },
-        },
-      },
-    );
+    },
+  });
 
-  const posts = useMemo(() => {
-    const nodes =
-      data?.pages.flatMap((page) => page.data.posts?.nodes ?? []) ?? [];
-    const activeFilter = FILTERS.find((item) => item.value === filter);
+  const posts =
+    data?.pages.flatMap((page) => page.data.posts?.nodes ?? []) ?? [];
+  const hasInitialError = isError && !data;
 
-    return activeFilter?.type
-      ? nodes.filter((node) => node.content.type === activeFilter.type)
-      : nodes;
-  }, [data, filter]);
+  const emptyState = (
+    <Empty className="min-h-80">
+      <EmptyTitle>{t('empty.title')}</EmptyTitle>
+      <EmptyDescription>{t('empty.description')}</EmptyDescription>
+    </Empty>
+  );
+
+  const errorState = (
+    <Empty className="min-h-80">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <WarningCircleIcon />
+        </EmptyMedia>
+        <EmptyTitle>{t('error.title')}</EmptyTitle>
+        <EmptyDescription>{t('error.description')}</EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={isFetching}
+          onClick={() => void refetch()}
+        >
+          {t('error.retry')}
+        </Button>
+      </EmptyContent>
+    </Empty>
+  );
+
+  const nextPageError = (
+    <div className="flex flex-col items-center gap-2 text-center">
+      <p className="text-muted-foreground text-sm">
+        {t('pagination-error.description')}
+      </p>
+      <Button
+        size="sm"
+        variant="outline"
+        disabled={isFetchingNextPage}
+        onClick={() => void fetchNextPage()}
+      >
+        {t('pagination-error.retry')}
+      </Button>
+    </div>
+  );
 
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <Tabs
           value={filter}
-          onValueChange={(value) => setFilter(value as Filter)}
+          onValueChange={(value) => setFilter(value as HomeFeedFilter)}
         >
           <TabsList>
-            <TabsTrigger value="all">{t('all')}</TabsTrigger>
-            <TabsTrigger value="shorts">{t('shorts')}</TabsTrigger>
-            <TabsTrigger value="articles">{t('articles')}</TabsTrigger>
-            <TabsTrigger value="questions">{t('questions')}</TabsTrigger>
+            <TabsTrigger value="all">{t('tabs.all')}</TabsTrigger>
+            <TabsTrigger value="shorts">{t('tabs.shorts')}</TabsTrigger>
+            <TabsTrigger value="articles">{t('tabs.articles')}</TabsTrigger>
+            <TabsTrigger value="questions">{t('tabs.questions')}</TabsTrigger>
           </TabsList>
         </Tabs>
       </div>
@@ -72,9 +113,14 @@ export default function HomeFeed() {
       <PostList
         items={posts.map((post) => toPostSummary(post.content))}
         isPending={isPending}
+        isError={hasInitialError}
         hasNextPage={!!hasNextPage}
         isFetchingNextPage={isFetchingNextPage}
+        isFetchNextPageError={isFetchNextPageError}
         fetchNextPage={fetchNextPage}
+        empty={emptyState}
+        error={errorState}
+        nextPageError={nextPageError}
       />
     </div>
   );

--- a/apps/web/src/app/(app)/(home)/_components/TrendingTags.tsx
+++ b/apps/web/src/app/(app)/(home)/_components/TrendingTags.tsx
@@ -4,6 +4,7 @@ import { TrendUpIcon } from '@phosphor-icons/react/dist/ssr';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { useState } from 'react';
+import { toast } from 'sonner';
 
 import { useGetTagRecommendations } from '@/api/__generated__/tag/tag';
 import { useFollowTag } from '@/components/feature/tag/hooks/useFollowTag';
@@ -21,8 +22,10 @@ export default function TrendingTags() {
   const { data: session } = useSession();
   const handle = session?.user.handle ?? '';
 
-  const { data, isPending } = useGetTagRecommendations();
+  const { data, isPending, isError, isFetching, refetch } =
+    useGetTagRecommendations({ type: 'TRENDING' });
   const tags = (data?.data.tags ?? []).slice(0, MAX_TRENDING_TAGS);
+  const hasInitialError = isError && !data;
 
   const [followingOverrides, setFollowingOverrides] = useState<
     Record<number, boolean>
@@ -47,12 +50,16 @@ export default function TrendingTags() {
     setPending(tagId, true);
     setFollowingOverrides((prev) => ({ ...prev, [tagId]: !isFollowing }));
 
+    const onError = () => {
+      setFollowingOverrides((prev) => ({ ...prev, [tagId]: isFollowing }));
+      toast.error(t('messages.follow-error'));
+    };
     const onSettled = () => setPending(tagId, false);
 
     if (isFollowing) {
-      unfollowTag({ tagId: String(tagId) }, { onSettled });
+      unfollowTag({ tagId: String(tagId) }, { onError, onSettled });
     } else {
-      followTag({ tagId: String(tagId) }, { onSettled });
+      followTag({ tagId: String(tagId) }, { onError, onSettled });
     }
   };
 
@@ -72,48 +79,64 @@ export default function TrendingTags() {
       </div>
 
       <div className="space-y-3">
-        {isPending
-          ? Array.from({ length: MAX_TRENDING_TAGS }).map((_, index) => (
-              <div key={index} className="flex items-center gap-2">
-                <div className="flex-1 space-y-1">
-                  <Skeleton className="h-3 w-20" />
-                  <Skeleton className="h-3 w-14" />
-                </div>
-                <Skeleton className="h-7 w-16" />
+        {isPending ? (
+          Array.from({ length: MAX_TRENDING_TAGS }).map((_, index) => (
+            <div key={index} className="flex items-center gap-2">
+              <div className="flex-1 space-y-1">
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-3 w-14" />
               </div>
-            ))
-          : tags.map((tag) => {
-              const isFollowing = followingOverrides[tag.id] ?? tag.isFollowing;
+              <Skeleton className="h-7 w-16" />
+            </div>
+          ))
+        ) : hasInitialError ? (
+          <div role="alert" className="flex flex-col items-start gap-2 py-2">
+            <p className="text-muted-foreground text-sm">
+              {t('error.description')}
+            </p>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={isFetching}
+              onClick={() => void refetch()}
+            >
+              {t('error.retry')}
+            </Button>
+          </div>
+        ) : tags.length === 0 ? (
+          <p className="text-muted-foreground py-2 text-sm">{t('empty')}</p>
+        ) : (
+          tags.map((tag) => {
+            const isFollowing = followingOverrides[tag.id] ?? tag.isFollowing;
 
-              return (
-                <div key={tag.id} className="flex items-center gap-2">
-                  <Link
-                    href={
-                      tag.projectHandle
-                        ? ROUTES.PROJECT_TAG(tag.projectHandle, String(tag.id))
-                        : ROUTES.TAG(String(tag.id))
-                    }
-                    className="min-w-0 flex-1 rounded-md hover:underline"
-                  >
-                    <p className="truncate text-sm font-semibold">
-                      #{tag.name}
-                    </p>
-                    <p className="text-muted-foreground truncate text-xs">
-                      {t('post-count', { count: tag.postCount })}
-                    </p>
-                  </Link>
+            return (
+              <div key={tag.id} className="flex items-center gap-2">
+                <Link
+                  href={
+                    tag.projectHandle
+                      ? ROUTES.PROJECT_TAG(tag.projectHandle, String(tag.id))
+                      : ROUTES.TAG(String(tag.id))
+                  }
+                  className="min-w-0 flex-1 rounded-md hover:underline"
+                >
+                  <p className="truncate text-sm font-semibold">#{tag.name}</p>
+                  <p className="text-muted-foreground truncate text-xs">
+                    {t('post-count', { count: tag.postCount })}
+                  </p>
+                </Link>
 
-                  <Button
-                    size="sm"
-                    variant={isFollowing ? 'outline' : 'default'}
-                    isPending={pendingIds.has(tag.id)}
-                    onClick={() => toggleFollow(tag.id, isFollowing)}
-                  >
-                    {isFollowing ? t('following') : t('follow')}
-                  </Button>
-                </div>
-              );
-            })}
+                <Button
+                  size="sm"
+                  variant={isFollowing ? 'outline' : 'default'}
+                  isPending={pendingIds.has(tag.id)}
+                  onClick={() => toggleFollow(tag.id, isFollowing)}
+                >
+                  {isFollowing ? t('following') : t('follow')}
+                </Button>
+              </div>
+            );
+          })
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/app/(app)/(home)/_components/homeFeed.test.ts
+++ b/apps/web/src/app/(app)/(home)/_components/homeFeed.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { PostType } from '@/components/feature/post/types/post';
+
+import { createHomeFeedParams } from './homeFeed';
+
+describe('홈 피드 요청 파라미터', () => {
+  it('전체 탭은 게시글 형태를 제한하지 않는다', () => {
+    expect(createHomeFeedParams('all', '50')).toEqual({
+      type: 'FOLLOWING',
+      first: '50',
+      after: '',
+    });
+  });
+
+  it.each([
+    ['shorts', PostType.SHORT],
+    ['articles', PostType.LONG],
+    ['questions', PostType.QUESTION],
+  ] as const)('%s 탭은 서버에 게시글 형태를 전달한다', (filter, postType) => {
+    expect(createHomeFeedParams(filter, '50')).toMatchObject({ postType });
+  });
+});

--- a/apps/web/src/app/(app)/(home)/_components/homeFeed.ts
+++ b/apps/web/src/app/(app)/(home)/_components/homeFeed.ts
@@ -1,0 +1,27 @@
+import type { GetPostRecommendationsParams } from '@/api/__generated__/types/GetPostRecommendationsParams';
+import { PostType } from '@/components/feature/post/types/post';
+
+export const HOME_FEED_FILTERS = [
+  { value: 'all', postType: undefined },
+  { value: 'shorts', postType: PostType.SHORT },
+  { value: 'articles', postType: PostType.LONG },
+  { value: 'questions', postType: PostType.QUESTION },
+] as const;
+
+export type HomeFeedFilter = (typeof HOME_FEED_FILTERS)[number]['value'];
+
+export function createHomeFeedParams(
+  filter: HomeFeedFilter,
+  pageSize: string,
+): GetPostRecommendationsParams {
+  const postType = HOME_FEED_FILTERS.find(
+    (item) => item.value === filter,
+  )?.postType;
+
+  return {
+    type: 'FOLLOWING',
+    first: pageSize,
+    after: '',
+    ...(postType ? { postType } : {}),
+  };
+}

--- a/apps/web/src/app/onboarding/_components/RecommendedFollows.tsx
+++ b/apps/web/src/app/onboarding/_components/RecommendedFollows.tsx
@@ -25,8 +25,12 @@ export const RecommendedFollows = forwardRef<
 
   const { data, isPending } = useGetUserRecommendations();
   const followedIds = useFollowedRecommendedUserIds();
-  const { mutate: followUser } = useFollowUser();
-  const { mutate: unfollowUser } = useUnfollowUser();
+  const { mutate: followUser } = useFollowUser({
+    invalidateUserRecommendations: false,
+  });
+  const { mutate: unfollowUser } = useUnfollowUser({
+    invalidateUserRecommendations: false,
+  });
 
   const [pendingIds, setPendingIds] = useState<Set<string>>(new Set());
 

--- a/apps/web/src/components/feature/post/hooks/postQueryKeys.test.ts
+++ b/apps/web/src/components/feature/post/hooks/postQueryKeys.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { isPostRecommendationQueryKey } from './postQueryKeys';
+
+describe('게시글 추천 쿼리 키 판별', () => {
+  it.each([
+    [['/posts/recommendations']],
+    [['/posts/recommendations', { type: 'FOLLOWING' }]],
+    [['infinite', '/posts/recommendations']],
+    [
+      [
+        'infinite',
+        '/posts/recommendations',
+        { type: 'FOLLOWING', postType: 'QUESTION' },
+      ],
+    ],
+  ])('일반 및 무한 추천 쿼리를 판별한다', (queryKey) => {
+    expect(isPostRecommendationQueryKey(queryKey)).toBe(true);
+  });
+
+  it.each([
+    [['/posts']],
+    [['infinite', '/posts']],
+    [['/users/recommendations']],
+  ])('추천 게시글 이외의 쿼리는 제외한다', (queryKey) => {
+    expect(isPostRecommendationQueryKey(queryKey)).toBe(false);
+  });
+});

--- a/apps/web/src/components/feature/post/hooks/postQueryKeys.ts
+++ b/apps/web/src/components/feature/post/hooks/postQueryKeys.ts
@@ -32,6 +32,16 @@ export function isPostRelatedQueryKey(queryKey: readonly unknown[]) {
   );
 }
 
+export function isPostRecommendationQueryKey(queryKey: readonly unknown[]) {
+  return getQueryPath(queryKey) === '/posts/recommendations';
+}
+
+export function invalidatePostRecommendationQueries(queryClient: QueryClient) {
+  return queryClient.invalidateQueries({
+    predicate: (query) => isPostRecommendationQueryKey(query.queryKey),
+  });
+}
+
 export function invalidatePostQueries(queryClient: QueryClient) {
   return queryClient.invalidateQueries({
     predicate: (query) => isPostRelatedQueryKey(query.queryKey),

--- a/apps/web/src/components/feature/post/viewer/PostList.tsx
+++ b/apps/web/src/components/feature/post/viewer/PostList.tsx
@@ -28,9 +28,11 @@ interface PostListProps {
   isError?: boolean;
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
+  isFetchNextPageError?: boolean;
   fetchNextPage: () => void;
   empty?: ReactNode;
   error?: ReactNode;
+  nextPageError?: ReactNode;
   end?: ReactNode;
   skeletonCount?: number;
 }
@@ -41,9 +43,11 @@ export default function PostList({
   isError,
   hasNextPage,
   isFetchingNextPage,
+  isFetchNextPageError = false,
   fetchNextPage,
   empty = <DefaultEmpty />,
   error,
+  nextPageError,
   end,
   skeletonCount = 3,
 }: PostListProps) {
@@ -54,10 +58,21 @@ export default function PostList({
   });
 
   useEffect(() => {
-    if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+    if (
+      entry?.isIntersecting &&
+      hasNextPage &&
+      !isFetchingNextPage &&
+      !isFetchNextPageError
+    ) {
       fetchNextPage();
     }
-  }, [entry?.isIntersecting, hasNextPage, isFetchingNextPage, fetchNextPage]);
+  }, [
+    entry?.isIntersecting,
+    hasNextPage,
+    isFetchingNextPage,
+    isFetchNextPageError,
+    fetchNextPage,
+  ]);
 
   if (isPending) {
     return (
@@ -96,6 +111,7 @@ export default function PostList({
             <Spinner />
           </div>
         )}
+        {isFetchNextPageError && nextPageError}
       </div>
 
       {!hasNextPage && end}

--- a/apps/web/src/components/feature/project/hooks/useFollowProject.ts
+++ b/apps/web/src/components/feature/project/hooks/useFollowProject.ts
@@ -1,14 +1,27 @@
-import { useQueryClient } from '@tanstack/react-query';
+import { type QueryClient, useQueryClient } from '@tanstack/react-query';
 
 import {
   getGetFollowedProjectsQueryKey,
   getGetMyProjectsQueryKey,
   getGetProjectByHandleQueryOptions,
+  getGetProjectRecommendationsQueryKey,
   useFollowProject as useFollowProjectMutation,
   useUnfollowProject as useUnfollowProjectMutation,
 } from '@/api/__generated__/project/project';
 import type { GetProjectsResponse } from '@/api/__generated__/types/GetProjectsResponse';
+import { getGetUserRecommendationsQueryKey } from '@/api/__generated__/user/user';
+import { invalidatePostRecommendationQueries } from '@/components/feature/post/hooks/postQueryKeys';
 import { useSession } from '@/lib/auth/client';
+
+function invalidateProjectFollowRecommendations(queryClient: QueryClient) {
+  queryClient.invalidateQueries({
+    queryKey: getGetProjectRecommendationsQueryKey(),
+  });
+  queryClient.invalidateQueries({
+    queryKey: getGetUserRecommendationsQueryKey(),
+  });
+  invalidatePostRecommendationQueries(queryClient);
+}
 
 export function useFollowProject() {
   const queryClient = useQueryClient();
@@ -25,6 +38,7 @@ export function useFollowProject() {
         queryClient.invalidateQueries({
           queryKey: getGetMyProjectsQueryKey(),
         });
+        invalidateProjectFollowRecommendations(queryClient);
 
         if (!session?.user.handle) {
           return;
@@ -54,6 +68,7 @@ export function useUnfollowProject() {
         queryClient.invalidateQueries({
           queryKey: getGetMyProjectsQueryKey(),
         });
+        invalidateProjectFollowRecommendations(queryClient);
 
         if (!session?.user.handle) {
           return;

--- a/apps/web/src/components/feature/tag/hooks/useFollowTag.ts
+++ b/apps/web/src/components/feature/tag/hooks/useFollowTag.ts
@@ -2,8 +2,10 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import {
   getGetFollowedTagsQueryKey,
+  getGetTagRecommendationsQueryKey,
   useFollowTag as useFollowTagMutation,
 } from '@/api/__generated__/tag/tag';
+import { invalidatePostRecommendationQueries } from '@/components/feature/post/hooks/postQueryKeys';
 
 interface UseFollowTagOptions {
   handle: string;
@@ -15,6 +17,12 @@ export function useFollowTag(options: UseFollowTagOptions) {
 
   return useFollowTagMutation({
     mutation: {
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: getGetTagRecommendationsQueryKey(),
+        });
+        invalidatePostRecommendationQueries(queryClient);
+      },
       onSettled: async () => {
         await queryClient.invalidateQueries({
           queryKey: getGetFollowedTagsQueryKey(options.handle),

--- a/apps/web/src/components/feature/tag/hooks/useUnfollowTag.ts
+++ b/apps/web/src/components/feature/tag/hooks/useUnfollowTag.ts
@@ -2,8 +2,10 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import {
   getGetFollowedTagsQueryKey,
+  getGetTagRecommendationsQueryKey,
   useUnfollowTag as useUnfollowTagMutation,
 } from '@/api/__generated__/tag/tag';
+import { invalidatePostRecommendationQueries } from '@/components/feature/post/hooks/postQueryKeys';
 
 interface UseUnfollowTagOptions {
   handle: string;
@@ -15,6 +17,12 @@ export function useUnfollowTag(options: UseUnfollowTagOptions) {
 
   return useUnfollowTagMutation({
     mutation: {
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: getGetTagRecommendationsQueryKey(),
+        });
+        invalidatePostRecommendationQueries(queryClient);
+      },
       onSettled: async () => {
         await queryClient.invalidateQueries({
           queryKey: getGetFollowedTagsQueryKey(options.handle),

--- a/apps/web/src/components/feature/user/hooks/useFollowUser.ts
+++ b/apps/web/src/components/feature/user/hooks/useFollowUser.ts
@@ -2,19 +2,24 @@ import { QueryClient, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type { GetProfileResponse } from '@/api/__generated__/types/GetProfileResponse';
 import {
+  getGetUserRecommendationsQueryKey,
   useFollowUser as useFollowUserMutation,
   useUnfollowUser as useUnfollowUserMutation,
 } from '@/api/__generated__/user/user';
+import { invalidatePostRecommendationQueries } from '@/components/feature/post/hooks/postQueryKeys';
 
 /**
- * Recommendation-style endpoints (e.g. GetRecommendations) don't return an
- * `isFollowing` flag, so followed state for those lists is tracked here
- * instead, keyed in the query cache so it survives remounts.
+ * 추천 API 응답에는 `isFollowing`이 없으므로 추천 목록의 팔로우 상태를 쿼리 캐시에 별도로 보관한다.
+ * 컴포넌트가 다시 마운트되어도 같은 상태를 유지하기 위한 캐시다.
  */
 export const FOLLOWED_RECOMMENDED_USER_IDS_QUERY_KEY = [
   'user',
   'followedRecommendedUserIds',
 ];
+
+interface UseUserFollowOptions {
+  invalidateUserRecommendations?: boolean;
+}
 
 export function useFollowedRecommendedUserIds() {
   const { data = [] } = useQuery<string[]>({
@@ -77,7 +82,9 @@ function removeFollowedRecommendedUserId(
   );
 }
 
-export function useFollowUser() {
+export function useFollowUser({
+  invalidateUserRecommendations = true,
+}: UseUserFollowOptions = {}) {
   const queryClient = useQueryClient();
 
   return useFollowUserMutation({
@@ -85,12 +92,20 @@ export function useFollowUser() {
       onSuccess: (_data, { followeeId }) => {
         setProfileFollowingState(queryClient, followeeId, true);
         addFollowedRecommendedUserId(queryClient, followeeId);
+        if (invalidateUserRecommendations) {
+          queryClient.invalidateQueries({
+            queryKey: getGetUserRecommendationsQueryKey(),
+          });
+        }
+        invalidatePostRecommendationQueries(queryClient);
       },
     },
   });
 }
 
-export function useUnfollowUser() {
+export function useUnfollowUser({
+  invalidateUserRecommendations = true,
+}: UseUserFollowOptions = {}) {
   const queryClient = useQueryClient();
 
   return useUnfollowUserMutation({
@@ -98,6 +113,12 @@ export function useUnfollowUser() {
       onSuccess: (_data, { followeeId }) => {
         setProfileFollowingState(queryClient, followeeId, false);
         removeFollowedRecommendedUserId(queryClient, followeeId);
+        if (invalidateUserRecommendations) {
+          queryClient.invalidateQueries({
+            queryKey: getGetUserRecommendationsQueryKey(),
+          });
+        }
+        invalidatePostRecommendationQueries(queryClient);
       },
     },
   });

--- a/docs/api/openapi3.yaml
+++ b/docs/api/openapi3.yaml
@@ -1192,6 +1192,12 @@ paths:
         required: false
         schema:
           type: string
+      - name: postType
+        in: query
+        description: "게시글 형태 필터. SHORT, LONG, QUESTION 중 하나를 사용한다."
+        required: false
+        schema:
+          type: string
       responses:
         "200":
           description: "200"


### PR DESCRIPTION
## 개요

홈 화면의 추천 기능을 실제 팔로우 관계와 일관되게 동작하도록 정비합니다.

- 게시글 피드의 `FOLLOWING` 후보에 팔로우한 **전역 태그**를 추가합니다.
- 홈 피드의 글 형태 필터를 클라이언트 후처리가 아닌 서버 조회 조건으로 적용합니다.
- 사용자·태그 추천 후보의 데이터 무결성과 결정적 정렬을 강화합니다.
- 홈 추천 영역에서 로딩·빈 결과·초기 오류·추가 페이지 오류를 구분하고 재시도 경로를 제공합니다.
- 사용자·프로젝트·태그 팔로우 변경 후 관련 추천 캐시가 즉시 갱신되도록 연결합니다.

## 배경 및 근본 원인

기존 홈 화면에는 다음 문제가 있었습니다.

1. `FOLLOWING` 게시글 추천은 팔로우한 사용자와 프로젝트만 후보로 사용했습니다. 사용자가 태그를 팔로우해도 해당 태그가 붙은 게시글은 홈 피드에 반영되지 않았습니다.
2. 홈의 `전체 / 짧은 글 / 긴 글 / 질문` 탭은 서버 후보를 글 형태별로 조회하지 않아 페이지 단위 결과와 화면 필터가 어긋날 수 있었습니다.
3. 추천 카드가 빈 결과와 요청 실패를 같은 화면처럼 처리해 사용자가 추천 대상이 없는지, 일시적인 오류인지 판단하기 어려웠습니다.
4. 추가 페이지 요청이 실패한 뒤 교차 관찰자가 같은 요청을 반복할 가능성이 있었습니다.
5. 팔로우 성공 후 게시글·사용자·프로젝트·태그 추천 쿼리가 충분히 갱신되지 않아 이전 추천 결과가 남을 수 있었습니다.
6. 사용자 추천에는 삭제 사용자, 온보딩을 완료하지 않은 사용자, 핸들이 없는 사용자가 후보가 될 여지가 있었습니다.
7. 인기 태그 집계는 개인 게시글 중심 조건을 별도로 사용해 공개 프로젝트 게시글을 일관되게 반영하지 못했고, 동률 정렬도 결정적이지 않았습니다.

## 서버 변경 사항

### 1. 팔로우 태그를 홈 피드 후보에 포함

`FOLLOWING` 게시글 후보 조건을 다음 세 신호의 합집합으로 구성했습니다.

- 팔로우한 사용자가 작성한 게시글
- 팔로우한 프로젝트의 게시글
- 팔로우한 전역 태그가 연결된 게시글

태그 조건은 `EXISTS` 서브쿼리로 구현해 하나의 게시글이 여러 팔로우 조건 또는 여러 태그에 동시에 일치해도 중복 행이 생성되지 않습니다.

또한 현재 태그 팔로우 정책에 맞춰 `project_id IS NULL`인 전역 태그만 후보 신호로 사용합니다. 비정상적인 프로젝트 태그 팔로우 데이터가 있더라도 홈 피드 후보에 포함되지 않습니다.

게시글 가시성은 기존 공통 조건인 `PostConditions.readablePublished(...)`를 그대로 사용합니다. 따라서:

- 공개 개인 게시글과 공개 프로젝트 게시글은 정상 노출됩니다.
- 비공개 프로젝트 게시글은 요청자가 해당 프로젝트의 팀원일 때만 노출됩니다.
- 초안과 숨김 게시글은 추천 후보에서 제외됩니다.

### 2. 게시글 형태 서버 필터 추가

`GET /posts/recommendations`에 선택적 `postType` 파라미터를 추가했습니다.

지원 값:

- `SHORT`
- `LONG`
- `QUESTION`

`PostRecommendationContext`와 후보 저장소까지 값을 전달해 페이지네이션 전에 서버 쿼리에서 필터링합니다. `postType`을 생략하면 기존처럼 모든 형태를 포함합니다.

OpenAPI 명세와 Orval 생성 타입도 함께 갱신했습니다.

### 3. 사용자 추천 후보 무결성 강화

프로젝트 겹침, 최근 팔로우 증가, 최근 가입 대체 후보에서 공통으로 다음 사용자를 제외합니다.

- 삭제된 사용자
- 온보딩을 완료하지 않은 사용자
- 핸들이 없는 사용자
- 요청자 본인
- 이미 팔로우한 사용자

집계 값이 같은 경우 사용자 ID를 보조 정렬 조건으로 사용해 같은 데이터에서는 항상 같은 순서가 나오도록 했습니다.

### 4. 인기 태그 집계 조건 통일

인기 태그 집계가 `PostConditions.feedVisible()`을 재사용하도록 변경했습니다.

이에 따라 최근 7일 내 게시된 다음 게시글이 집계 대상입니다.

- 공개 개인 게시글
- 공개 프로젝트 게시글

다음 게시글은 제외됩니다.

- 비공개 프로젝트 게시글
- 초안 게시글
- 숨김 게시글
- 집계 기간 이전 게시글

전역·검증 완료 태그 및 미팔로우 태그 조건은 유지하며, 사용 횟수가 같은 경우 태그 ID로 안정적인 보조 정렬을 적용했습니다.

## 웹 변경 사항

### 1. 홈 피드 상태 처리

- 탭 선택 값을 서버 `postType` 파라미터로 변환합니다.
- 초기 로딩, 빈 피드, 초기 요청 오류를 분리합니다.
- 초기 오류 화면에 재시도 버튼을 제공합니다.
- 추가 페이지 요청 실패 시 기존 게시글은 유지하고 하단에 별도 오류 및 재시도 버튼을 표시합니다.
- 추가 페이지 오류 상태에서는 교차 관찰자의 자동 재호출을 중단해 반복 요청을 방지합니다.

### 2. 사용자 발견 카드

- 추천 사용자 프로필 이미지를 표시합니다.
- 전체 버튼을 한꺼번에 잠그지 않고 사용자별 팔로우 진행 상태를 관리합니다.
- 로딩, 빈 추천, 초기 오류를 구분하고 오류 재시도를 제공합니다.
- 백그라운드 재조회 실패 시 이미 받은 추천 데이터는 계속 표시합니다.

### 3. 인기 태그 카드

- 명시적으로 `TRENDING` 추천 채널을 요청합니다.
- 로딩, 빈 추천, 초기 오류를 구분하고 오류 재시도를 제공합니다.
- 태그별 팔로우 진행 상태와 낙관적 UI를 적용합니다.
- 팔로우/해제 실패 시 이전 상태로 되돌리고 오류 토스트를 표시합니다.
- 백그라운드 재조회 실패 시 기존 추천 데이터를 유지합니다.

### 4. 팔로우 후 추천 캐시 갱신

팔로우 관계에 따라 영향을 받는 추천 쿼리만 갱신합니다.

- 사용자 팔로우/해제: 사용자 추천, 게시글 추천
- 프로젝트 팔로우/해제: 프로젝트 추천, 사용자 추천, 게시글 추천
- 태그 팔로우/해제: 태그 추천, 게시글 추천

일반 쿼리와 무한 쿼리 형태의 게시글 추천 키를 모두 판별하도록 공통 헬퍼를 추가했습니다.

온보딩 사용자 추천 화면은 선택한 사용자를 같은 화면에서 다시 해제할 수 있어야 하므로, 해당 화면에서는 사용자 추천 목록 자체의 즉시 무효화만 선택적으로 끕니다. 게시글 추천 캐시 갱신은 그대로 수행합니다.

## 사용자 영향

- 태그를 팔로우하면 해당 태그의 새 게시글이 홈 피드 후보에 포함됩니다.
- 글 형태 탭마다 실제 서버 페이지네이션 결과가 정확히 일치합니다.
- 추천 대상이 없는 상태와 서버 요청 실패를 구분할 수 있습니다.
- 네트워크 오류가 발생해도 이미 불러온 피드와 추천 결과가 사라지지 않습니다.
- 팔로우 직후 관련 추천 결과가 오래된 상태로 남는 현상이 줄어듭니다.
- 비공개 프로젝트 게시글의 접근 정책은 기존과 동일하게 유지됩니다.

## 테스트

### 서버

- 사용자·프로젝트·전역 태그 팔로우 후보 합집합 및 중복 방지
- 프로젝트 태그 팔로우 데이터 제외
- 비공개 프로젝트 게시글의 팀원/외부 사용자 가시성 분리
- `scope` 및 `postType` 필터
- 사용자 추천의 삭제·미온보딩·핸들 누락 사용자 제외
- 인기 태그의 공개 프로젝트 포함 및 비공개·초안·숨김·기간 외 게시글 제외
- 추천 동률 시 안정적 정렬

### 웹

- 홈 탭별 `postType` 요청 파라미터 변환
- 일반/무한 게시글 추천 쿼리 키 판별

## 검증 결과

- [x] `apps/server ./gradlew build`
- [x] `apps/web pnpm format`
- [x] `apps/web pnpm lint`
- [x] `apps/web pnpm exec tsc --noEmit`
- [x] `apps/web pnpm test:unit` — 24개 테스트 통과
- [x] `apps/web pnpm build`
- [x] `git diff --check`

## 범위 참고

- 이번 변경은 기존 추천 채널과 정렬 정책을 유지하면서 후보 조건·무결성·상태 처리를 보완합니다.
- 태그 팔로우 신호는 현재 제품 정책대로 전역 태그에만 적용합니다.
- 추천 점수, 투표, 평판 등 새로운 참여 지표는 추가하지 않습니다.