### PR TITLE
fix: 모바일 태그 입력 확정 경로 개선

### DIFF
--- a/apps/web/public/locales/ko.json
+++ b/apps/web/public/locales/ko.json
@@ -2515,13 +2515,15 @@
         "suggestions": "혹은 아래 템플릿을 사용해보세요"
       },
       "tags": {
-        "placeholder": "태그를 입력하세요 (Enter 또는 쉼표로 추가)",
+        "placeholder": "태그를 검색하거나 입력하세요",
+        "input-label": "태그 검색 또는 추가",
+        "create": "‘{name}’ 태그 추가",
         "post-count": "{count}개의 게시물",
         "max-tags": "태그는 최대 {count}개까지 추가할 수 있습니다",
         "loading": "태그를 검색하는 중...",
         "not-found": "태그를 찾을 수 없습니다",
         "project-tag": "프로젝트 태그입니다",
-        "helper": "목록에 없는 태그는 Enter로 새로 만들 수 있어요. 새 태그는 관리자 확인 후 노출돼요."
+        "helper": "목록에 없는 태그도 새로 추가할 수 있어요. 새 태그는 관리자 확인 후 노출돼요."
       },
       "cover": {
         "add": "커버 추가",

--- a/apps/web/src/components/feature/post/editor/PostEditor.tsx
+++ b/apps/web/src/components/feature/post/editor/PostEditor.tsx
@@ -37,7 +37,7 @@ import { EditorTemplates } from './components/EditorTemplates';
 import { MathDialog } from './components/MathDialog';
 import { PostTypeSelector } from './components/PostTypeSelector';
 import { SeriesSelect, SeriesSelection } from './components/SeriesSelect';
-import { TagInput, TagValue } from './components/TagInput';
+import { TagInput, type TagInputHandle, TagValue } from './components/TagInput';
 import { CoverPicker } from './cover/CoverPicker';
 import { type CoverState, initialCoverState } from './cover/coverState';
 import { renderCoverToFile } from './cover/generators';
@@ -159,6 +159,19 @@ export default function PostEditor({
       .filter((tag) => tag.projectHandle)
       .map((tag) => ({ name: tag.name, isProjectTag: true })),
   ]);
+  const tagsRef = useRef(tags);
+  const tagInputRef = useRef<TagInputHandle>(null);
+  const submitTagCommitFailedRef = useRef(false);
+  const handleTagsChange = (nextTags: TagValue[]) => {
+    tagsRef.current = nextTags;
+    setTags(nextTags);
+  };
+  const commitPendingTag = () => {
+    return tagInputRef.current?.commitPending() ?? true;
+  };
+  const handleSubmitPointerDown = () => {
+    submitTagCommitFailedRef.current = !commitPendingTag();
+  };
   const [series, setSeries] = useState<SeriesSelection | null>(() =>
     initialSeries
       ? {
@@ -386,6 +399,12 @@ export default function PostEditor({
       return;
     }
 
+    const pointerCommitFailed = submitTagCommitFailedRef.current;
+    submitTagCommitFailedRef.current = false;
+    if (pointerCommitFailed) {
+      return;
+    }
+
     if (editor.isEmpty) {
       toast.error(t('messages.empty-content'));
       return;
@@ -401,6 +420,10 @@ export default function PostEditor({
     }
 
     setValidationMessage(null);
+    if (!commitPendingTag()) {
+      return;
+    }
+    const submitTags = tagsRef.current;
 
     setIsPreparingCover(true);
     let coverResult: Awaited<ReturnType<typeof resolveCoverSubmit>>;
@@ -432,8 +455,10 @@ export default function PostEditor({
       title,
       type,
       status,
-      tags: tags.filter((tag) => !tag.isProjectTag).map((tag) => tag.name),
-      projectTags: tags
+      tags: submitTags
+        .filter((tag) => !tag.isProjectTag)
+        .map((tag) => tag.name),
+      projectTags: submitTags
         .filter((tag) => tag.isProjectTag)
         .map((tag) => tag.name),
       series,
@@ -603,8 +628,9 @@ export default function PostEditor({
           {t('sidebar.tags')}
         </h3>
         <TagInput
+          ref={tagInputRef}
           tags={tags}
-          onChange={setTags}
+          onChange={handleTagsChange}
           projectHandle={project?.handle}
           accentRing={ACCENT_RING[type]}
         />
@@ -614,12 +640,14 @@ export default function PostEditor({
         <h3 className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           {t('sidebar.series')}
         </h3>
-        <SeriesSelect
-          value={series}
-          onChange={setSeries}
-          projectHandle={project?.handle}
-          accentRing={ACCENT_RING[type]}
-        />
+        <div data-tag-commit-target="" onPointerDownCapture={commitPendingTag}>
+          <SeriesSelect
+            value={series}
+            onChange={setSeries}
+            projectHandle={project?.handle}
+            accentRing={ACCENT_RING[type]}
+          />
+        </div>
       </section>
 
       <div
@@ -630,15 +658,19 @@ export default function PostEditor({
       >
         {canSaveDraft && (
           <Button
+            data-tag-commit-target=""
             variant="outline"
             disabled={isSubmitting || isPreparingCover || isEditorEmpty}
+            onPointerDownCapture={handleSubmitPointerDown}
             onClick={() => handleSubmit(PostStatus.DRAFT)}
           >
             {draftActionLabel}
           </Button>
         )}
         <Button
+          data-tag-commit-target=""
           disabled={isSubmitting || isPreparingCover || isEditorEmpty}
+          onPointerDownCapture={handleSubmitPointerDown}
           onClick={() => handleSubmit(PostStatus.PUBLISHED)}
         >
           {publishActionLabel}

--- a/apps/web/src/components/feature/post/editor/components/TagInput.tsx
+++ b/apps/web/src/components/feature/post/editor/components/TagInput.tsx
@@ -1,7 +1,18 @@
 'use client';
 
+import type { BaseUIEvent } from '@base-ui/react/types';
+import { PlusIcon } from '@phosphor-icons/react';
 import { useTranslations } from 'next-intl';
-import { type KeyboardEvent, useState } from 'react';
+import {
+  type ClipboardEvent,
+  type KeyboardEvent,
+  type FocusEvent as ReactFocusEvent,
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
 import { toast } from 'sonner';
 
 import { RemovableTagBadge, TagBadge } from '@/components/feature/tag/TagBadge';
@@ -20,7 +31,17 @@ import {
 } from '@/components/ui/combobox';
 import { cn } from '@/lib/utils';
 
-const MAXIMUM_ALLOWED_TAGS = 5;
+import {
+  MAXIMUM_ALLOWED_TAGS,
+  appendTagNames,
+  normalizeTagName,
+  parseDelimitedTagInput,
+  parsePastedTagInput,
+} from './tagInputUtils';
+
+// 표준 HTML 토큰과 내부 DOM 연결 표식은 번역하지 않는다.
+const TAG_ENTER_KEY_HINT = 'enter' as const;
+const TAG_COMMIT_TARGET_SELECTOR = '[data-tag-commit-target]';
 
 export interface TagValue {
   name: string;
@@ -29,6 +50,7 @@ export interface TagValue {
 
 interface TagOption extends TagValue {
   postCount?: number;
+  isCreate?: boolean;
 }
 
 interface TagInputProps {
@@ -38,164 +60,342 @@ interface TagInputProps {
   projectHandle?: string;
 }
 
-export function TagInput({
-  tags,
-  onChange,
-  accentRing,
-  projectHandle,
-}: TagInputProps) {
-  const t = useTranslations('components.editor.tags');
-  const anchor = useComboboxAnchor();
-
-  const [inputValue, setInputValue] = useState('');
-  const {
-    setQuery,
-    tags: searchedTags,
-    isPending,
-  } = useTagSearch({ handle: projectHandle });
-
-  const updateInputValue = (value: string) => {
-    setInputValue(value);
-    setQuery(value);
-  };
-
-  const suggestions: TagOption[] = isPending
-    ? []
-    : searchedTags.map((tag) => ({
-        name: tag.name,
-        isProjectTag: tag.projectHandle != null,
-        postCount: tag.postCount,
-      }));
-
-  const tagNames = tags.map((tag) => tag.name);
-
-  const addTag = (name: string, isProjectTag: boolean) => {
-    if (tags.length >= MAXIMUM_ALLOWED_TAGS) {
-      toast.error(
-        t('max-tags', {
-          count: MAXIMUM_ALLOWED_TAGS,
-        }),
-      );
-      return;
-    }
-
-    const trimmed = name.trim().toLowerCase();
-    if (!trimmed || tagNames.includes(trimmed)) {
-      return;
-    }
-
-    onChange([...tags, { name: trimmed, isProjectTag }]);
-    updateInputValue('');
-  };
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.nativeEvent.isComposing) {
-      return;
-    }
-
-    if (e.key === 'Enter' || e.key === ',') {
-      e.preventDefault();
-      addTag(e.currentTarget.value, !!projectHandle);
-    }
-  };
-
-  return (
-    <div className="flex flex-col gap-1.5">
-      <Combobox
-        items={suggestions}
-        multiple
-        value={tags}
-        onValueChange={(next) => {
-          if (next.length <= tags.length) {
-            onChange(next);
-            return;
-          }
-
-          if (next.length > MAXIMUM_ALLOWED_TAGS) {
-            toast.error(
-              t('max-tags', {
-                count: MAXIMUM_ALLOWED_TAGS,
-              }),
-            );
-            return;
-          }
-
-          onChange(next);
-          updateInputValue('');
-        }}
-        inputValue={inputValue}
-        onInputValueChange={updateInputValue}
-        isItemEqualToValue={(item, value) =>
-          item.name === value.name && item.isProjectTag === value.isProjectTag
-        }
-        itemToStringLabel={(item) => item.name}
-        filter={null}
-      >
-        <ComboboxChips
-          ref={anchor}
-          className={cn(
-            'focus-within:ring-2',
-            accentRing ?? 'focus-within:ring-primary/30',
-          )}
-        >
-          {tags.map((tag) => (
-            <ComboboxChip
-              key={`${tag.isProjectTag}:${tag.name}`}
-              showRemove={false}
-              className="bg-transparent px-0"
-            >
-              <RemovableTagBadge
-                name={tag.name}
-                isProjectTag={tag.isProjectTag}
-                variant="secondary"
-                onRemove={() =>
-                  onChange(
-                    tags.filter(
-                      (t) =>
-                        !(
-                          t.name === tag.name &&
-                          t.isProjectTag === tag.isProjectTag
-                        ),
-                    ),
-                  )
-                }
-              />
-            </ComboboxChip>
-          ))}
-
-          <ComboboxChipsInput
-            placeholder={tags.length === 0 ? t('placeholder') : ''}
-            onKeyDown={handleKeyDown}
-            onInput={(e) => setQuery(e.currentTarget.value)}
-          />
-        </ComboboxChips>
-
-        <ComboboxContent anchor={anchor}>
-          <ComboboxList>
-            <ComboboxCollection>
-              {(item: TagOption) => (
-                <ComboboxItem key={item.name} value={item}>
-                  <TagBadge
-                    name={item.name}
-                    isProjectTag={item.isProjectTag}
-                    variant="secondary"
-                  />
-                  {item.postCount !== undefined && (
-                    <span className="text-xs text-muted-foreground">
-                      {t('post-count', { count: item.postCount })}
-                    </span>
-                  )}
-                </ComboboxItem>
-              )}
-            </ComboboxCollection>
-            <ComboboxEmpty>
-              {isPending ? t('loading') : t('not-found')}
-            </ComboboxEmpty>
-          </ComboboxList>
-        </ComboboxContent>
-      </Combobox>
-
-      <p className="px-1 text-xs text-muted-foreground">{t('helper')}</p>
-    </div>
-  );
+export interface TagInputHandle {
+  commitPending: () => boolean;
 }
+
+export const TagInput = forwardRef<TagInputHandle, TagInputProps>(
+  function TagInput(
+    { tags, onChange, accentRing, projectHandle }: TagInputProps,
+    ref,
+  ) {
+    const t = useTranslations('components.editor.tags');
+    const anchor = useComboboxAnchor();
+
+    const [inputValue, setInputValue] = useState('');
+    const inputElementRef = useRef<HTMLInputElement>(null);
+    const inputValueRef = useRef('');
+    const pendingInputHandledRef = useRef(true);
+    const tagsRef = useRef(tags);
+    const highlightedItemRef = useRef<TagOption | undefined>(undefined);
+
+    useEffect(() => {
+      tagsRef.current = tags;
+    }, [tags]);
+
+    const {
+      setQuery,
+      tags: searchedTags,
+      isPending,
+    } = useTagSearch({ handle: projectHandle });
+
+    const updateInputValue = (value: string) => {
+      pendingInputHandledRef.current = value.length === 0;
+      inputValueRef.current = value;
+      setInputValue(value);
+      setQuery(value);
+    };
+
+    const suggestions: TagOption[] = isPending
+      ? []
+      : searchedTags.map((tag) => ({
+          name: tag.name,
+          isProjectTag: tag.projectHandle != null,
+          postCount: tag.postCount,
+        }));
+
+    const applyTags = (nextTags: TagValue[]) => {
+      tagsRef.current = nextTags;
+      onChange(nextTags);
+    };
+
+    const resolveTag = (name: string): TagValue => {
+      const exactSuggestions = suggestions.filter(
+        (tag) => normalizeTagName(tag.name) === name,
+      );
+      const preferredProjectTag = !!projectHandle;
+      const exactSuggestion =
+        exactSuggestions.find(
+          (tag) => tag.isProjectTag === preferredProjectTag,
+        ) ?? exactSuggestions[0];
+
+      return {
+        name,
+        isProjectTag: exactSuggestion?.isProjectTag ?? preferredProjectTag,
+      };
+    };
+
+    const commitTagNames = (rawNames: readonly string[], remainder = '') => {
+      const currentTags = tagsRef.current;
+      const result = appendTagNames(currentTags, rawNames, resolveTag);
+
+      if (result.tags.length !== currentTags.length) {
+        applyTags(result.tags);
+      }
+
+      const normalizedRemainder = normalizeTagName(remainder);
+      const remainderExceedsLimit =
+        normalizedRemainder.length > 0 &&
+        result.tags.length >= MAXIMUM_ALLOWED_TAGS &&
+        !result.tags.some(
+          (tag) => normalizeTagName(tag.name) === normalizedRemainder,
+        );
+      const nextInput = remainderExceedsLimit ? '' : remainder;
+      updateInputValue(nextInput);
+
+      if (result.limitExceeded || remainderExceedsLimit) {
+        toast.error(
+          t('max-tags', {
+            count: MAXIMUM_ALLOWED_TAGS,
+          }),
+        );
+      }
+
+      return !result.limitExceeded && !remainderExceedsLimit;
+    };
+
+    const commitPendingInput = () => {
+      if (pendingInputHandledRef.current) {
+        return true;
+      }
+
+      return commitTagNames([
+        inputElementRef.current?.value ?? inputValueRef.current,
+      ]);
+    };
+
+    useImperativeHandle(ref, () => ({ commitPending: commitPendingInput }));
+
+    const handleKeyDown = (e: BaseUIEvent<KeyboardEvent<HTMLInputElement>>) => {
+      if (e.key !== 'Enter') {
+        return;
+      }
+
+      if (e.nativeEvent.isComposing || e.keyCode === 229) {
+        e.preventBaseUIHandler();
+        return;
+      }
+
+      if (highlightedItemRef.current) {
+        return;
+      }
+
+      e.preventDefault();
+      e.preventBaseUIHandler();
+      commitTagNames([e.currentTarget.value]);
+    };
+
+    const handlePaste = (e: BaseUIEvent<ClipboardEvent<HTMLInputElement>>) => {
+      const input = e.currentTarget;
+      const pastedValue = e.clipboardData.getData('text');
+      const selectionStart = input.selectionStart ?? input.value.length;
+      const selectionEnd = input.selectionEnd ?? selectionStart;
+      const nextValue =
+        input.value.slice(0, selectionStart) +
+        pastedValue +
+        input.value.slice(selectionEnd);
+      const pastedTagNames = parsePastedTagInput(nextValue);
+
+      if (!pastedTagNames) {
+        return;
+      }
+
+      e.preventDefault();
+      e.preventBaseUIHandler();
+      commitTagNames(pastedTagNames);
+    };
+
+    const handleBlur = (e: ReactFocusEvent<HTMLInputElement>) => {
+      highlightedItemRef.current = undefined;
+
+      if (
+        e.relatedTarget instanceof Element &&
+        e.relatedTarget.closest(TAG_COMMIT_TARGET_SELECTOR)
+      ) {
+        commitPendingInput();
+        return;
+      }
+
+      updateInputValue('');
+    };
+
+    const normalizedInput = normalizeTagName(inputValue);
+    const hasExactSuggestion = suggestions.some(
+      (tag) => normalizeTagName(tag.name) === normalizedInput,
+    );
+    const hasSelectedTag = tags.some(
+      (tag) => normalizeTagName(tag.name) === normalizedInput,
+    );
+    const showCreate =
+      !isPending &&
+      normalizedInput.length > 0 &&
+      !hasExactSuggestion &&
+      !hasSelectedTag &&
+      tags.length < MAXIMUM_ALLOWED_TAGS;
+    const options: TagOption[] = showCreate
+      ? [
+          ...suggestions,
+          {
+            name: normalizedInput,
+            isProjectTag: !!projectHandle,
+            isCreate: true,
+          },
+        ]
+      : suggestions;
+
+    return (
+      <div className="flex flex-col gap-1.5">
+        <Combobox
+          items={options}
+          multiple
+          value={tags}
+          onValueChange={(next) => {
+            const normalizedNext = next.map(({ name, isProjectTag }) => ({
+              name,
+              isProjectTag,
+            }));
+            const currentTags = tagsRef.current;
+
+            if (normalizedNext.length <= currentTags.length) {
+              applyTags(normalizedNext);
+              return;
+            }
+
+            if (normalizedNext.length > MAXIMUM_ALLOWED_TAGS) {
+              toast.error(
+                t('max-tags', {
+                  count: MAXIMUM_ALLOWED_TAGS,
+                }),
+              );
+              return;
+            }
+
+            applyTags(normalizedNext);
+            updateInputValue('');
+          }}
+          inputValue={inputValue}
+          onInputValueChange={(value, eventDetails) => {
+            if (eventDetails.reason !== 'input-change') {
+              updateInputValue(value);
+              return;
+            }
+
+            const parsed = parseDelimitedTagInput(value);
+            if (!parsed) {
+              updateInputValue(value);
+              return;
+            }
+
+            eventDetails.cancel();
+            commitTagNames(parsed.completedValues, parsed.remainder);
+          }}
+          onOpenChange={(open) => {
+            if (open) {
+              return;
+            }
+
+            highlightedItemRef.current = undefined;
+            updateInputValue('');
+          }}
+          onItemHighlighted={(item) => {
+            highlightedItemRef.current = item;
+          }}
+          isItemEqualToValue={(item, value) =>
+            item.name === value.name && item.isProjectTag === value.isProjectTag
+          }
+          itemToStringLabel={(item) => item.name}
+          filter={null}
+        >
+          <ComboboxChips
+            ref={anchor}
+            className={cn(
+              'focus-within:ring-2',
+              accentRing ?? 'focus-within:ring-primary/30',
+            )}
+          >
+            {tags.map((tag) => (
+              <ComboboxChip
+                key={`${tag.isProjectTag}:${tag.name}`}
+                showRemove={false}
+                className="bg-transparent px-0"
+              >
+                <RemovableTagBadge
+                  name={tag.name}
+                  isProjectTag={tag.isProjectTag}
+                  variant="secondary"
+                  onRemove={() =>
+                    applyTags(
+                      tagsRef.current.filter(
+                        (t) =>
+                          !(
+                            t.name === tag.name &&
+                            t.isProjectTag === tag.isProjectTag
+                          ),
+                      ),
+                    )
+                  }
+                />
+              </ComboboxChip>
+            ))}
+
+            <ComboboxChipsInput
+              ref={inputElementRef}
+              aria-label={t('input-label')}
+              disabled={tags.length >= MAXIMUM_ALLOWED_TAGS}
+              enterKeyHint={TAG_ENTER_KEY_HINT}
+              inputMode="text"
+              placeholder={tags.length === 0 ? t('placeholder') : ''}
+              onBlur={handleBlur}
+              onCompositionStart={() => {
+                pendingInputHandledRef.current = false;
+              }}
+              onKeyDown={handleKeyDown}
+              onPaste={handlePaste}
+            />
+          </ComboboxChips>
+
+          <ComboboxContent anchor={anchor}>
+            <ComboboxList>
+              <ComboboxCollection>
+                {(item: TagOption) => (
+                  <ComboboxItem
+                    key={`${item.isCreate ? 'create' : 'existing'}:${item.isProjectTag}:${item.name}`}
+                    value={item}
+                    className={item.isCreate ? 'min-h-11' : undefined}
+                  >
+                    {item.isCreate ? (
+                      <>
+                        <PlusIcon className="shrink-0" />
+                        <span className="truncate">
+                          {t('create', { name: item.name })}
+                        </span>
+                      </>
+                    ) : (
+                      <>
+                        <TagBadge
+                          name={item.name}
+                          isProjectTag={item.isProjectTag}
+                          variant="secondary"
+                        />
+                        {item.postCount !== undefined && (
+                          <span className="text-xs text-muted-foreground">
+                            {t('post-count', { count: item.postCount })}
+                          </span>
+                        )}
+                      </>
+                    )}
+                  </ComboboxItem>
+                )}
+              </ComboboxCollection>
+              <ComboboxEmpty>
+                {isPending ? t('loading') : t('not-found')}
+              </ComboboxEmpty>
+            </ComboboxList>
+          </ComboboxContent>
+        </Combobox>
+
+        <p className="px-1 text-xs text-muted-foreground">{t('helper')}</p>
+      </div>
+    );
+  },
+);

--- a/apps/web/src/components/feature/post/editor/components/tagInputUtils.test.ts
+++ b/apps/web/src/components/feature/post/editor/components/tagInputUtils.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  appendTagNames,
+  normalizeTagName,
+  parseDelimitedTagInput,
+  parsePastedTagInput,
+} from './tagInputUtils';
+
+describe('태그 입력 구분자 해석', () => {
+  it('쉼표가 없으면 미확정 입력으로 유지한다', () => {
+    expect(parseDelimitedTagInput('react')).toBeNull();
+  });
+
+  it('ASCII 쉼표 앞의 값을 확정하고 마지막 값을 남긴다', () => {
+    expect(parseDelimitedTagInput('react,next')).toEqual({
+      completedValues: ['react'],
+      remainder: 'next',
+    });
+  });
+
+  it('전각 쉼표와 여러 태그 붙여넣기를 처리한다', () => {
+    expect(parseDelimitedTagInput('리액트，next,typescript，')).toEqual({
+      completedValues: ['리액트', 'next', 'typescript'],
+      remainder: '',
+    });
+  });
+
+  it('쉼표가 포함된 붙여넣기는 마지막 값까지 확정한다', () => {
+    expect(parsePastedTagInput('react,nextjs,typescript')).toEqual([
+      'react',
+      'nextjs',
+      'typescript',
+    ]);
+  });
+
+  it('쉼표가 없는 붙여넣기는 일반 입력으로 처리한다', () => {
+    expect(parsePastedTagInput('react')).toBeNull();
+  });
+});
+
+describe('태그 목록 확정', () => {
+  it('태그 이름의 공백과 대소문자를 정규화한다', () => {
+    expect(normalizeTagName('  React  ')).toBe('react');
+  });
+
+  it('빈 값과 이름이 같은 태그를 제외하고 원본 배열을 변경하지 않는다', () => {
+    const currentTags = [{ name: 'react', isProjectTag: false }];
+    const result = appendTagNames(
+      currentTags,
+      [' React ', '', 'Next', 'next'],
+      (name) => ({ name, isProjectTag: false }),
+    );
+
+    expect(result).toEqual({
+      tags: [
+        { name: 'react', isProjectTag: false },
+        { name: 'next', isProjectTag: false },
+      ],
+      limitExceeded: false,
+    });
+    expect(currentTags).toEqual([{ name: 'react', isProjectTag: false }]);
+  });
+
+  it('최대 개수까지만 추가하고 초과 여부를 반환한다', () => {
+    const currentTags = ['one', 'two', 'three', 'four'].map((name) => ({
+      name,
+      isProjectTag: false,
+    }));
+    const result = appendTagNames(currentTags, ['five', 'six'], (name) => ({
+      name,
+      isProjectTag: false,
+    }));
+
+    expect(result.tags.map((tag) => tag.name)).toEqual([
+      'one',
+      'two',
+      'three',
+      'four',
+      'five',
+    ]);
+    expect(result.limitExceeded).toBe(true);
+  });
+
+  it('후행 쉼표 없는 대량 붙여넣기도 초과 태그를 감지한다', () => {
+    const pastedTagNames = parsePastedTagInput('one,two,three,four,five,six');
+    expect(pastedTagNames).not.toBeNull();
+
+    const result = appendTagNames([], pastedTagNames ?? [], (name) => ({
+      name,
+      isProjectTag: false,
+    }));
+
+    expect(result.tags.map((tag) => tag.name)).toEqual([
+      'one',
+      'two',
+      'three',
+      'four',
+      'five',
+    ]);
+    expect(result.limitExceeded).toBe(true);
+  });
+});

--- a/apps/web/src/components/feature/post/editor/components/tagInputUtils.ts
+++ b/apps/web/src/components/feature/post/editor/components/tagInputUtils.ts
@@ -1,0 +1,70 @@
+export const MAXIMUM_ALLOWED_TAGS = 5;
+
+const TAG_DELIMITER_PATTERN = /[,，]/u;
+
+export interface ParsedTagInput {
+  completedValues: string[];
+  remainder: string;
+}
+
+interface NamedTag {
+  name: string;
+}
+
+interface AppendTagNamesResult<T> {
+  tags: T[];
+  limitExceeded: boolean;
+}
+
+export function normalizeTagName(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function parseDelimitedTagInput(value: string): ParsedTagInput | null {
+  const values = value.split(TAG_DELIMITER_PATTERN);
+  if (values.length === 1) {
+    return null;
+  }
+
+  return {
+    completedValues: values.slice(0, -1),
+    remainder: values.at(-1) ?? '',
+  };
+}
+
+export function parsePastedTagInput(value: string): string[] | null {
+  const parsed = parseDelimitedTagInput(value);
+  if (!parsed) {
+    return null;
+  }
+
+  return [...parsed.completedValues, parsed.remainder];
+}
+
+export function appendTagNames<T extends NamedTag>(
+  currentTags: readonly T[],
+  rawNames: readonly string[],
+  createTag: (normalizedName: string) => T,
+  maximumAllowedTags = MAXIMUM_ALLOWED_TAGS,
+): AppendTagNamesResult<T> {
+  const tags = [...currentTags];
+  const names = new Set(tags.map((tag) => normalizeTagName(tag.name)));
+  let limitExceeded = false;
+
+  rawNames.forEach((rawName) => {
+    const name = normalizeTagName(rawName);
+    if (!name || names.has(name)) {
+      return;
+    }
+
+    if (tags.length >= maximumAllowedTags) {
+      limitExceeded = true;
+      return;
+    }
+
+    tags.push(createTag(name));
+    names.add(name);
+  });
+
+  return { tags, limitExceeded };
+}


### PR DESCRIPTION
## 개요

모바일 환경에서 태그 입력 후 쉼표 또는 키보드 액션 키를 사용해도 태그가 추가되지 않고, 다음 필드로 이동하거나 글을 저장할 때 입력값이 사라지는 문제를 해결합니다.

PC의 키보드 이벤트에만 의존하던 태그 확정 로직을 실제 입력값 기반으로 변경하고, 모바일 IME에서도 사용할 수 있는 명시적인 새 태그 추가 경로와 제출 직전 동기화 경로를 추가했습니다.

## 문제 상황

기존 태그 입력은 `keydown` 이벤트에서 `Enter` 또는 ASCII 쉼표를 감지할 때만 태그를 확정했습니다.

이 구조에서는 다음과 같은 문제가 발생했습니다.

- 모바일 가상 키보드가 쉼표를 `input`/조합 입력으로 삽입하고 별도의 `keydown`을 발생시키지 않으면 태그가 확정되지 않음
- 삼성 키보드의 예측 입력이 일반 문자와 구두점까지 `isComposing=true`로 보고할 수 있어 기존 조합 가드에서 Enter와 쉼표가 모두 무시됨
- 모바일 키보드의 액션 키가 Enter 대신 “다음” 또는 “이동”으로 표시되고 다음 입력으로 포커스만 이동함
- 콤보박스에서 선택되지 않은 원문은 태그 상태와 별개이므로 포커스가 빠지거나 저장할 때 조용히 누락될 수 있음

## 주요 변경 사항

### 1. 입력값 기반 쉼표 처리

- `keydown` 대신 Combobox의 `onInputValueChange`에서 실제 입력값을 파싱합니다.
- ASCII 쉼표(`,`)와 전각 쉼표(`，`)를 구분자로 지원합니다.
- 한 이벤트에 여러 문자가 들어오는 모바일 IME 입력도 처리합니다.
- 구분자 앞의 완성된 값만 태그로 확정하고 마지막 미완성 값은 입력란에 유지합니다.
- 쉼표가 포함된 붙여넣기는 마지막 토큰까지 일괄 확정합니다.
  - 예: `react,nextjs,typescript` → 태그 3개
- 태그 이름의 trim, 소문자 변환, 이름 기준 중복 제거, 최대 5개 제한을 공통 유틸로 통합했습니다.

### 2. 모바일에서 명시적으로 사용할 수 있는 추가 경로

- 입력값과 일치하는 기존 태그가 없으면 검색 목록에 `‘태그명’ 태그 추가` 항목을 노출합니다.
- 해당 항목은 일반 Combobox item으로 구성해 터치, 포커스 유지, 키보드 탐색 동작을 기존 제안 항목과 동일하게 유지합니다.
- 모바일 키보드에 Enter 성격의 액션을 힌트로 제공하도록 `enterKeyHint="enter"`와 `inputMode="text"`를 설정했습니다.
- placeholder와 도움말에서 Enter 전용 표현을 제거해 기기 독립적인 문구로 변경했습니다.

### 3. IME 조합 입력 보호

- 한글 등 IME 조합 중 Enter는 태그 확정으로 처리하지 않습니다.
- 조합 중 Enter가 Base UI 내부의 강조 항목 선택으로 전달되지 않도록 내부 핸들러도 차단합니다.
- Android 삼성 키보드의 always-composing 동작 때문에 쉼표 처리는 `isComposing` 값이 아니라 실제 입력값의 구분자를 기준으로 처리합니다.
- 조합 중 저장/발행을 탭하는 경우 React 상태보다 실제 input DOM 값을 우선 읽어 마지막 조합 문자열이 누락되지 않도록 했습니다.

### 4. 미확정 입력의 확정·폐기 정책 명시

| 사용자 동작 | 처리 |
| --- | --- |
| 쉼표/전각 쉼표 입력 | 구분자 앞 값을 태그로 확정 |
| 비조합 상태에서 Enter | 현재 값을 태그로 확정 |
| 새 태그 추가 항목 선택 | 해당 값을 태그로 확정 |
| 시리즈 입력으로 이동 | 현재 미확정 값을 태그로 확정 |
| 임시저장/발행 클릭 | 저장 요청 전에 현재 값을 태그로 확정 |
| 그 외 영역으로 포커스 이동 | 미확정 값을 보존하지 않고 폐기 |

시리즈와 저장 버튼의 pointer-down 단계에서 먼저 확정하고, 키보드 이동을 위해 input blur의 `relatedTarget`도 확인합니다. 팝업이 열리지 않는 자동완성/일부 IME 입력도 이 경로로 처리됩니다.

### 5. 제출 시점 동기화

- 확정된 태그 배열을 React state와 ref에 함께 반영합니다.
- 저장 핸들러는 cover 처리 전 ref 스냅샷을 사용하므로 blur → click → 비동기 업로드 순서에서도 새 태그가 payload에서 누락되지 않습니다.
- 최대 5개 제한 때문에 미확정 입력 확정이 실패하면 오류 안내 후 해당 저장/발행 요청을 한 번 중단합니다.
- 전역 태그와 프로젝트 태그를 분리하는 기존 제출 규칙은 유지합니다.

### 6. 테스트 추가

태그 파싱과 목록 확정 로직을 순수 유틸로 분리하고 다음 회귀 테스트를 추가했습니다.

- 쉼표가 없는 미확정 입력
- ASCII/전각 쉼표
- 여러 태그 입력과 붙여넣기
- 후행 쉼표 없는 붙여넣기의 마지막 토큰
- trim 및 소문자 정규화
- 빈 값과 중복 제거
- 원본 배열 불변성
- 최대 5개 제한 및 초과 감지

## 사용자 영향

- 모바일에서도 쉼표 또는 명시적인 추가 항목으로 태그를 안정적으로 추가할 수 있습니다.
- 시리즈로 이동하거나 글을 저장할 때 입력 중인 태그가 조용히 사라지지 않습니다.
- 일반적인 바깥 이동에서는 미확정 문자열을 자동 생성하지 않고 폐기해 의도치 않은 새 태그 생성을 방지합니다.
- PC의 기존 Enter 입력과 태그 제안 선택 흐름은 유지됩니다.

## 검증

- `pnpm format`
- `pnpm lint`
- `pnpm test:unit` — 6개 파일, 39개 테스트 통과
- `pnpm build` — Next.js 프로덕션 빌드 및 TypeScript 검사 통과

## 수동 확인 권장 항목

모바일 viewport 에뮬레이션만으로 실제 OS IME 동작을 완전히 재현할 수 없으므로 아래 실기기 확인을 권장합니다.

- Android Chrome / Samsung Internet / 인앱 브라우저
- 삼성 키보드 예측 입력 ON / Gboard
- iOS Safari
- 한글 조합 중 Enter
- 쉼표 입력과 전각 쉼표 입력
- `react,nextjs,typescript` 붙여넣기
- 태그 입력 후 모바일 “다음”으로 시리즈 이동
- 태그 입력 직후 임시저장/발행
- 최대 5개 도달 및 초과 안내

## 범위

- 서버 API와 데이터 모델 변경 없음
- 태그 최대 개수 및 전역/프로젝트 태그 구분 규칙 변경 없음
