### PR TITLE
fix: 게시물 사이드바 스크롤 동작 개선

### DIFF
--- a/apps/web/src/app/(app)/posts/[slug]/page.tsx
+++ b/apps/web/src/app/(app)/posts/[slug]/page.tsx
@@ -11,10 +11,8 @@ import {
   type PostType,
 } from '@/components/feature/post/types/post';
 import { PostCard } from '@/components/feature/post/viewer/PostCard';
-import PostComments from '@/components/feature/post/viewer/PostComments';
 import { PostProvider } from '@/components/feature/post/viewer/PostContext';
-import { PostSeriesCard } from '@/components/feature/post/viewer/PostSeriesCard';
-import { PostTableOfContents } from '@/components/feature/post/viewer/PostTableOfContents';
+import { PostViewerSidebar } from '@/components/feature/post/viewer/PostViewerSidebar';
 import { RelatedPosts } from '@/components/feature/post/viewer/RelatedPosts';
 import { TwoColumnLayout } from '@/components/layout/TwoColumnLayout';
 import SyncError, { ErrorCode } from '@/lib/error';
@@ -133,20 +131,15 @@ export default async function Post({ params }: PostProps) {
         <TwoColumnLayout
           main={<PostCard slug={slug} />}
           side={
-            <div className="flex flex-col gap-6">
-              <PostTableOfContents />
-              <PostSeriesCard slug={slug} />
-              {commentsEnabled && postType && postId !== undefined ? (
-                <PostComments
-                  slug={slug}
-                  postId={postId}
-                  postType={postType}
-                  isPostAuthor={isPostAuthor}
-                  canComment={canComment}
-                  requiresMembership={requiresMembership}
-                />
-              ) : null}
-            </div>
+            <PostViewerSidebar
+              slug={slug}
+              commentsEnabled={commentsEnabled}
+              postId={postId}
+              postType={postType}
+              isPostAuthor={isPostAuthor}
+              canComment={canComment}
+              requiresMembership={requiresMembership}
+            />
           }
         />
       </PostProvider>

--- a/apps/web/src/app/(app)/projects/[handle]/posts/[slug]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[handle]/posts/[slug]/page.tsx
@@ -8,10 +8,8 @@ import { getGetPostBySlugQueryKey } from '@/api/__generated__/post/post';
 import { COMMENT_PAGE_SIZE } from '@/components/feature/post/constants';
 import type { PostType } from '@/components/feature/post/types/post';
 import { PostCard } from '@/components/feature/post/viewer/PostCard';
-import PostComments from '@/components/feature/post/viewer/PostComments';
 import { PostProvider } from '@/components/feature/post/viewer/PostContext';
-import { PostSeriesCard } from '@/components/feature/post/viewer/PostSeriesCard';
-import { PostTableOfContents } from '@/components/feature/post/viewer/PostTableOfContents';
+import { PostViewerSidebar } from '@/components/feature/post/viewer/PostViewerSidebar';
 import { RelatedPosts } from '@/components/feature/post/viewer/RelatedPosts';
 import { TwoColumnLayout } from '@/components/layout/TwoColumnLayout';
 import SyncError, { ErrorCode } from '@/lib/error';
@@ -116,20 +114,15 @@ export default async function Post({ params }: PostProps) {
         <TwoColumnLayout
           main={<PostCard slug={slug} />}
           side={
-            <div className="flex flex-col gap-6">
-              <PostTableOfContents />
-              <PostSeriesCard slug={slug} />
-              {commentsEnabled && postType && postId !== undefined ? (
-                <PostComments
-                  slug={slug}
-                  postId={postId}
-                  postType={postType}
-                  isPostAuthor={isPostAuthor}
-                  canComment={canComment}
-                  requiresMembership={requiresMembership}
-                />
-              ) : null}
-            </div>
+            <PostViewerSidebar
+              slug={slug}
+              commentsEnabled={commentsEnabled}
+              postId={postId}
+              postType={postType}
+              isPostAuthor={isPostAuthor}
+              canComment={canComment}
+              requiresMembership={requiresMembership}
+            />
           }
         />
       </PostProvider>

--- a/apps/web/src/components/feature/post/editor/PostEditor.tsx
+++ b/apps/web/src/components/feature/post/editor/PostEditor.tsx
@@ -201,7 +201,7 @@ export default function PostEditor({
     if (!el) return;
     el.style.height = 'auto';
     el.style.height = `${el.scrollHeight}px`;
-  }, [title]);
+  }, [title, type]);
 
   const commandSearchTerms = useMemo<CommandSearchTerms>(
     () =>
@@ -649,7 +649,11 @@ export default function PostEditor({
           />
         </div>
       </section>
+    </div>
+  );
 
+  const sideFooter = (
+    <div className="mt-6 flex flex-col gap-4 lg:mt-0 lg:border-t lg:border-border lg:bg-background lg:pt-4">
       <div
         className={cn(
           'grid gap-2',
@@ -695,5 +699,12 @@ export default function PostEditor({
     </div>
   );
 
-  return <TwoColumnLayout main={main} side={side} />;
+  return (
+    <TwoColumnLayout
+      main={main}
+      side={side}
+      sideFooter={sideFooter}
+      sideViewportScrollable
+    />
+  );
 }

--- a/apps/web/src/components/feature/post/editor/components/SeriesSelect.tsx
+++ b/apps/web/src/components/feature/post/editor/components/SeriesSelect.tsx
@@ -4,6 +4,11 @@ import { ListNumbersIcon, PlusIcon, XIcon } from '@phosphor-icons/react';
 import { useTranslations } from 'next-intl';
 import { useMemo, useState } from 'react';
 
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 
 import { usePostSeriesList } from '../../hooks/usePostSeriesList';
@@ -82,27 +87,31 @@ export function SeriesSelect({
   };
 
   return (
-    <div className="relative">
-      <input
-        value={query}
-        placeholder={t('placeholder')}
-        onChange={(event) => {
-          setQuery(event.target.value);
-          setOpen(true);
-        }}
-        onFocus={() => setOpen(true)}
-        onBlur={() => setOpen(false)}
-        className={cn(
-          'w-full rounded-lg border border-border bg-background px-3 py-2.5 text-sm outline-none focus:ring-2',
-          accentRing ?? 'focus:ring-primary/30',
-        )}
-      />
+    <Popover open={open && (trimmed.length > 0 || filtered.length > 0)}>
+      <PopoverAnchor asChild>
+        <input
+          value={query}
+          placeholder={t('placeholder')}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onBlur={() => setOpen(false)}
+          className={cn(
+            'w-full rounded-lg border border-border bg-background px-3 py-2.5 text-sm outline-none focus:ring-2',
+            accentRing ?? 'focus:ring-primary/30',
+          )}
+        />
+      </PopoverAnchor>
 
-      {open && (trimmed.length > 0 || filtered.length > 0) && (
-        <ul
-          className="absolute z-50 mt-1 max-h-60 w-full overflow-y-auto rounded-lg border border-border bg-popover py-1 shadow-md"
-          onMouseDown={(event) => event.preventDefault()}
-        >
+      <PopoverContent
+        align="start"
+        className="max-h-60 w-(--radix-popover-trigger-width) gap-0 overflow-y-auto rounded-lg p-0 py-1"
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        onMouseDown={(event) => event.preventDefault()}
+      >
+        <ul>
           {filtered.map((item) => (
             <li key={item.externalId}>
               <button
@@ -145,7 +154,7 @@ export function SeriesSelect({
             </li>
           )}
         </ul>
-      )}
-    </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/apps/web/src/components/feature/post/viewer/PostComments.tsx
+++ b/apps/web/src/components/feature/post/viewer/PostComments.tsx
@@ -44,6 +44,7 @@ import { PostType } from '../types/post';
 import { COMMENT_COMPOSER_ID } from './utils/commentComposer';
 
 interface PostCommentsProps {
+  className?: string;
   slug: string;
   postId: number;
   postType: PostType;
@@ -239,6 +240,7 @@ function PostCommentItem({
 }
 
 export default function PostComments({
+  className,
   slug,
   postId,
   postType,
@@ -313,7 +315,7 @@ export default function PostComments({
   }
 
   return (
-    <Card className="gap-0 p-0 lg:max-h-[calc(100vh-7rem)]">
+    <Card className={cn('gap-0 p-0 lg:max-h-[calc(100svh-7.5rem)]', className)}>
       <div className="flex items-center justify-between px-5 py-4">
         <h2 className="text-sm font-semibold">
           {t('title')} {comments.length > 0 && `· ${comments.length}`}

--- a/apps/web/src/components/feature/post/viewer/PostSeriesCard.tsx
+++ b/apps/web/src/components/feature/post/viewer/PostSeriesCard.tsx
@@ -50,7 +50,7 @@ export function PostSeriesCard({ slug }: PostSeriesCardProps) {
       : ROUTES.POST(postSlug);
 
   return (
-    <Card>
+    <Card className="shrink-0">
       <CardHeader>
         <CardDescription>{t('label')}</CardDescription>
         <CardTitle className="text-base">{series.name}</CardTitle>

--- a/apps/web/src/components/feature/post/viewer/PostViewerSidebar.tsx
+++ b/apps/web/src/components/feature/post/viewer/PostViewerSidebar.tsx
@@ -1,0 +1,60 @@
+import type { PostType } from '../types/post';
+import PostComments from './PostComments';
+import { PostSeriesCard } from './PostSeriesCard';
+import { PostTableOfContents } from './PostTableOfContents';
+
+interface PostViewerSidebarProps {
+  slug: string;
+  commentsEnabled: boolean;
+  postId?: number;
+  postType?: PostType;
+  isPostAuthor: boolean;
+  canComment: boolean;
+  requiresMembership: boolean;
+}
+
+export function PostViewerSidebar({
+  slug,
+  commentsEnabled,
+  postId,
+  postType,
+  isPostAuthor,
+  canComment,
+  requiresMembership,
+}: PostViewerSidebarProps) {
+  const showComments =
+    commentsEnabled && postType !== undefined && postId !== undefined;
+
+  return (
+    <div
+      className={
+        showComments
+          ? 'flex flex-col gap-6 lg:max-h-[calc(100svh-7.5rem)]'
+          : 'flex flex-col gap-6'
+      }
+    >
+      <div
+        className={
+          showComments
+            ? 'flex flex-col gap-6 empty:hidden lg:min-h-0 lg:shrink lg:overflow-y-auto lg:overscroll-contain lg:px-1 lg:[scrollbar-gutter:stable]'
+            : 'flex flex-col gap-6 empty:hidden'
+        }
+      >
+        <PostTableOfContents />
+        <PostSeriesCard slug={slug} />
+      </div>
+
+      {showComments && (
+        <PostComments
+          slug={slug}
+          postId={postId}
+          postType={postType}
+          isPostAuthor={isPostAuthor}
+          canComment={canComment}
+          requiresMembership={requiresMembership}
+          className="lg:max-h-[45svh] lg:shrink-0"
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/feature/post/viewer/components/PostTableOfContentsList.tsx
+++ b/apps/web/src/components/feature/post/viewer/components/PostTableOfContentsList.tsx
@@ -21,7 +21,7 @@ export function PostTableOfContentsList({
   }
 
   return (
-    <Card>
+    <Card className="shrink-0">
       <CardHeader>
         <CardTitle className="text-base">{t('title')}</CardTitle>
       </CardHeader>

--- a/apps/web/src/components/layout/TwoColumnLayout.tsx
+++ b/apps/web/src/components/layout/TwoColumnLayout.tsx
@@ -10,6 +10,8 @@ import ROUTES from '@/util/routes';
 interface TwoColumnLayoutProps {
   main: ReactNode;
   side?: ReactNode;
+  sideFooter?: ReactNode;
+  sideViewportScrollable?: boolean;
   hideSideOnMobile?: boolean;
   reverseSideOnMobile?: boolean;
 }
@@ -17,6 +19,8 @@ interface TwoColumnLayoutProps {
 export function TwoColumnLayout({
   main,
   side,
+  sideFooter,
+  sideViewportScrollable,
   hideSideOnMobile,
   reverseSideOnMobile,
 }: TwoColumnLayoutProps) {
@@ -42,9 +46,23 @@ export function TwoColumnLayout({
             'lg:sticky lg:top-7',
             hideSideOnMobile && 'hidden lg:block',
             reverseSideOnMobile && 'order-1 lg:order-2',
+            sideViewportScrollable &&
+              'lg:flex lg:h-[calc(100svh-7.5rem)] lg:min-h-0 lg:flex-col lg:overflow-clip',
           )}
         >
-          {side}
+          <div
+            className={cn(
+              sideViewportScrollable &&
+                'lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:overscroll-contain lg:pr-2 lg:pl-1 lg:[scrollbar-gutter:stable]',
+            )}
+          >
+            {side}
+          </div>
+          {sideFooter && (
+            <div className={cn(sideViewportScrollable && 'lg:shrink-0')}>
+              {sideFooter}
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## 개요

글 작성·수정 화면과 게시글 상세 화면의 오른쪽 사이드바가 긴 목차나 글 종류 전환에 의해 잘리거나 축소되는 문제를 해결합니다.

이번 변경은 사이드바의 스크롤 책임을 명확히 분리하고, 저장/게시 액션과 댓글처럼 항상 접근 가능해야 하는 영역을 별도 고정 영역으로 구성합니다. 서버 API, 데이터 모델, 스키마 변경은 없습니다.

## 문제 상황

### 글 작성·수정 화면

- 목차가 길어지면 오른쪽 사이드바 전체 높이가 화면을 넘어 태그, 시리즈, 저장/게시 버튼에 접근하기 어려웠습니다.
- 블로그 글을 TIL 또는 질문으로 전환하면 사이드바의 저장 버튼이 화면 중간으로 올라오고, 다시 블로그로 돌아와도 원래 높이로 복구되지 않았습니다.
- 긴 사이드바를 내부 스크롤 영역으로 만들면 기존 시리즈 검색 목록이 overflow 경계에 잘릴 수 있었습니다.
- SHORT 유형에서 숨겨졌던 여러 줄 제목 입력창이 LONG/QUESTION으로 돌아왔을 때 기존 높이로 다시 계산되지 않았습니다.

### 게시글 상세 화면

- 목차, 시리즈, 댓글을 한 열에 순서대로 배치해 긴 목차가 댓글 영역을 아래로 밀었습니다.
- 사용자는 본문을 끝까지 내려야 댓글 작성기와 댓글 목록을 확인할 수 있었습니다.

## 원인

1. 기존 `TwoColumnLayout`의 사이드 영역은 sticky 위치만 적용되고 뷰포트 기준 높이와 내부 overflow 경계가 없었습니다.
2. 저장/게시 버튼이 스크롤되는 설정 콘텐츠와 같은 흐름에 있어 목차 길이에 직접 영향을 받았습니다.
3. 외부 사이드바에 `overflow: hidden`을 적용하면 스크롤바는 보이지 않지만 브라우저가 해당 요소를 프로그램 방식으로 스크롤할 수 있습니다. 글 종류 라디오에 포커스가 이동할 때 외부 요소의 `scrollTop`이 변경되고, 같은 DOM이 재사용되면서 축소된 것처럼 보이는 위치가 유지됐습니다.
4. 게시글 상세 화면은 목차·시리즈·댓글을 하나의 일반 flex 흐름에 배치했습니다.
5. 시리즈 검색 목록은 입력 아래의 absolute 요소여서 새 overflow 경계 밖으로 나가면 클리핑될 수 있었습니다.
6. 제목 자동 높이 계산 effect가 `title`만 구독해, 글 종류 변경에 따른 입력창 재마운트를 감지하지 못했습니다.

## 변경 내용

### 공용 2열 레이아웃 확장

- `TwoColumnLayout`에 opt-in 속성을 추가했습니다.
  - `sideViewportScrollable`: 데스크톱에서 사이드바를 뷰포트 높이로 제한하고 내부 콘텐츠만 독립 스크롤
  - `sideFooter`: 스크롤 콘텐츠와 분리된 하단 고정 영역
- 외부 컨테이너는 `overflow: clip`을 사용해 시각적 클리핑은 유지하면서 숨은 스크롤 컨테이너가 되지 않도록 했습니다.
- 실제 스크롤은 `min-height: 0`과 `overflow-y: auto`가 적용된 내부 영역 하나가 담당합니다.
- `lg` 미만에서는 고정 높이와 내부 스크롤을 해제해 기존 모바일 문서 흐름을 유지합니다.

### 에디터 사이드바

- 목차·공개 범위·종류·태그·시리즈를 하나의 내부 스크롤 영역으로 묶었습니다.
- 임시 저장/게시/변경사항 저장 버튼은 `sideFooter`로 분리해 화면 하단에서 계속 접근할 수 있도록 했습니다.
- 블로그 ↔ TIL/질문 전환 시 외부 사이드바의 숨은 scroll position이 누적되지 않도록 수정했습니다.
- 제목 높이 계산을 글 종류 변경 시에도 다시 실행해 여러 줄 제목이 정상 복원되도록 했습니다.
- 시리즈 검색 결과를 Portal 기반 Popover로 전환해 사이드바 overflow 경계에 잘리지 않도록 했습니다.

### 게시글 상세 사이드바

- 개인 글과 프로젝트 글이 공통으로 사용하는 `PostViewerSidebar`를 추가했습니다.
- 상단 목차·시리즈 영역은 남은 높이 안에서 독립 스크롤합니다.
- 댓글 영역은 하단에 별도로 보존하며 최대 높이를 `45svh`로 제한했습니다.
- 댓글이 많을 때는 기존 댓글 목록 내부 스크롤을 유지합니다.
- 목차와 시리즈 카드는 flex 축소로 잘리지 않도록 `shrink-0`을 적용했습니다.

## 사용자 영향

- 긴 목차가 있어도 에디터의 태그·시리즈와 저장/게시 버튼에 접근할 수 있습니다.
- 글 종류를 반복해서 변경해도 오른쪽 사이드바 높이와 저장 버튼 위치가 유지됩니다.
- 게시글 상세 진입 직후 긴 목차와 관계없이 댓글 영역을 확인할 수 있습니다.
- 목차 위에서 스크롤하면 목차 영역만, 본문 위에서 스크롤하면 본문만 이동합니다.
- 모바일/태블릿의 단일 열 레이아웃은 기존처럼 자연스럽게 아래로 이어집니다.

## 검증

### 자동 검증

- `pnpm exec prettier --check src`
- `pnpm lint`
- `pnpm test:unit` — 6개 파일, 39개 테스트 통과
- `pnpm exec tsc --noEmit`
- `pnpm build` — Next.js 프로덕션 빌드 통과
- `git diff --check`

### 브라우저 검증

- LONG → TIL → LONG, LONG → QUESTION → LONG 반복 전환 후 사이드바 높이와 하단 버튼 위치 유지
- 여러 줄 제목의 높이 복원 확인
- 긴 목차에서 사이드바 내부 스크롤과 본문 스크롤이 독립적으로 동작하는지 확인
- 게시글 상세 첫 화면에서 댓글 영역 노출 확인
- 긴 댓글 목록의 내부 스크롤 확인
- 데스크톱과 `lg` 미만 반응형 흐름 확인
