### PR TITLE
fix: STOMP 알림 구독 인가 추가 및 사용자 목적지 전환

### DIFF
--- a/apps/server/src/main/java/com/skkil/sync/config/SecurityConfig.java
+++ b/apps/server/src/main/java/com/skkil/sync/config/SecurityConfig.java
@@ -45,7 +45,11 @@ public class SecurityConfig {
       throws Exception {
     http.securityMatcher("/**")
         .addFilterBefore(absoluteSessionTimeoutFilter, SecurityContextHolderFilter.class)
-        .csrf(csrf -> csrf.spa())
+        // SockJS 폴백 전송(xhr_send 등)은 POST지만 클라이언트가 커스텀 헤더를 실을
+        // 수 없어 HTTP 레벨 CSRF를 통과할 수 없다(fail-closed). /ws는 핸드셰이크의
+        // Origin 허용 목록과 STOMP CONNECT 프레임의 CSRF 검증(WebSocketSecurityConfig의
+        // csrfChannelInterceptor)이 대신 보호한다.
+        .csrf(csrf -> csrf.spa().ignoringRequestMatchers("/ws/**"))
         .formLogin(formLogin -> formLogin.disable())
         .logout(
             logout ->

--- a/apps/server/src/main/java/com/skkil/sync/config/WebSocketConfig.java
+++ b/apps/server/src/main/java/com/skkil/sync/config/WebSocketConfig.java
@@ -19,7 +19,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   @Override
   public void configureMessageBroker(MessageBrokerRegistry registry) {
     registry.setApplicationDestinationPrefixes("/app");
-    registry.enableSimpleBroker("/topic");
+    // 브로드캐스트 네임스페이스(/topic)는 의도적으로 열지 않는다. 유일한 실시간
+    // 소비자인 알림이 사용자 목적지(/user/queue/**)로만 발행되므로, 목적지에
+    // 사용자 식별자를 넣고 아무나 구독하는 실수를 구조적으로 막는다.
+    registry.enableSimpleBroker("/queue");
     registry.setPreservePublishOrder(true);
   }
 

--- a/apps/server/src/main/java/com/skkil/sync/config/WebSocketSecurityConfig.java
+++ b/apps/server/src/main/java/com/skkil/sync/config/WebSocketSecurityConfig.java
@@ -1,0 +1,54 @@
+package com.skkil.sync.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.SimpMessageType;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.config.annotation.web.socket.EnableWebSocketSecurity;
+import org.springframework.security.messaging.access.intercept.MessageMatcherDelegatingAuthorizationManager;
+import org.springframework.security.messaging.web.csrf.CsrfChannelInterceptor;
+
+/**
+ * STOMP 프레임 레벨 인가. HTTP 필터 체인은 핸드셰이크까지만 보호하고, 이후 SUBSCRIBE/SEND 프레임은 clientInboundChannel을 타므로 여기서
+ * 별도로 인가해야 한다. 규칙에 없는 목적지는 전부 거부하는 기본 거부 정책이라, 새 목적지를 열려면 이 파일에 명시적으로 추가해야 한다.
+ */
+@Configuration
+@ConditionalOnProperty(name = "app.websocket.enabled", havingValue = "true", matchIfMissing = false)
+@EnableWebSocketSecurity
+public class WebSocketSecurityConfig {
+
+  @Bean
+  AuthorizationManager<Message<?>> messageAuthorizationManager(
+      MessageMatcherDelegatingAuthorizationManager.Builder messages) {
+    return messages
+        .simpTypeMatchers(
+            SimpMessageType.CONNECT,
+            SimpMessageType.DISCONNECT,
+            SimpMessageType.UNSUBSCRIBE,
+            SimpMessageType.HEARTBEAT)
+        .permitAll()
+        // 사용자 목적지는 브로커가 세션별로 해소하므로, 인증만 요구하면 각자 자기
+        // 알림만 받는다. 목적지에 사용자 식별자를 넣는 방식(/topic/notifications/{id})은
+        // 로그인한 아무나 남의 알림을 구독할 수 있어 금지 — enableSimpleBroker에서
+        // /topic을 열지 않는 것도 같은 이유다.
+        .simpSubscribeDestMatchers("/user/queue/notifications")
+        .authenticated()
+        .anyMessage()
+        .denyAll()
+        .build();
+  }
+
+  /**
+   * 기본 {@link org.springframework.security.messaging.web.csrf.XorCsrfChannelInterceptor}는 XOR 마스킹된
+   * 토큰만 받는데, 이 앱의 CSRF 설정({@code csrf.spa()})은 클라이언트가 {@code XSRF-TOKEN} 쿠키의 원본 값을 그대로 헤더에 싣는 SPA
+   * 방식이다. HTTP 경로의 {@code SpaCsrfTokenRequestHandler}가 원본 토큰을 받는 것과 동일하게, STOMP CONNECT도 평문 비교
+   * 인터셉터로 맞춘다. 빈 이름은 Spring Security가 교체 지점으로 조회하는 계약이므로 바꾸면 안 된다.
+   */
+  @Bean(name = "csrfChannelInterceptor")
+  ChannelInterceptor csrfChannelInterceptor() {
+    return new CsrfChannelInterceptor();
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/notification/channel/InAppNotificationChannel.java
+++ b/apps/server/src/main/java/com/skkil/sync/notification/channel/InAppNotificationChannel.java
@@ -2,6 +2,7 @@ package com.skkil.sync.notification.channel;
 
 import com.skkil.sync.notification.constant.ChannelType;
 import com.skkil.sync.notification.dto.data.NotificationSummary;
+import com.skkil.sync.user.model.User;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
@@ -9,6 +10,8 @@ import org.springframework.stereotype.Component;
 @Component
 @ConditionalOnProperty(name = "app.websocket.enabled", havingValue = "true", matchIfMissing = false)
 public class InAppNotificationChannel implements NotificationChannel {
+
+  private static final String NOTIFICATIONS_DESTINATION = "/queue/notifications";
 
   private final SimpMessagingTemplate messagingTemplate;
 
@@ -21,8 +24,14 @@ public class InAppNotificationChannel implements NotificationChannel {
     return ChannelType.IN_APP;
   }
 
+  /**
+   * 사용자 목적지로 발행한다 — 클라이언트는 {@code /user/queue/notifications}를 구독하고, 브로커가 세션별 목적지로 해소하므로 목적지 문자열에
+   * 수신자 식별자가 노출되지 않는다. 첫 인자는 STOMP 세션 Principal 이름과 일치해야 하며, 이 앱의 세션 Principal 이름은 이메일이다 ({@code
+   * AuthenticatedUser.getName()} — 세션 무효화가 이메일로 조회하는 것과 같은 계약).
+   */
   @Override
-  public void send(Long to, NotificationSummary notification) {
-    messagingTemplate.convertAndSend("/topic/notifications/" + to, notification);
+  public void send(User recipient, NotificationSummary notification) {
+    messagingTemplate.convertAndSendToUser(
+        recipient.getEmail(), NOTIFICATIONS_DESTINATION, notification);
   }
 }

--- a/apps/server/src/main/java/com/skkil/sync/notification/channel/NotificationChannel.java
+++ b/apps/server/src/main/java/com/skkil/sync/notification/channel/NotificationChannel.java
@@ -2,10 +2,11 @@ package com.skkil.sync.notification.channel;
 
 import com.skkil.sync.notification.constant.ChannelType;
 import com.skkil.sync.notification.dto.data.NotificationSummary;
+import com.skkil.sync.user.model.User;
 
 public interface NotificationChannel {
 
   ChannelType type();
 
-  void send(Long recipientId, NotificationSummary notification);
+  void send(User recipient, NotificationSummary notification);
 }

--- a/apps/server/src/main/java/com/skkil/sync/notification/service/NotificationProcessorService.java
+++ b/apps/server/src/main/java/com/skkil/sync/notification/service/NotificationProcessorService.java
@@ -72,7 +72,7 @@ public class NotificationProcessorService {
     }
 
     log.debug("Sending notification {} via channel {}", notification.getId(), ChannelType.IN_APP);
-    channel.send(event.getRecipientId(), toDto(notification));
+    channel.send(notification.getUser(), toDto(notification));
   }
 
   private Notification createNotification(NotificationEvent event) {

--- a/apps/server/src/test/java/com/skkil/sync/config/WebSocketSecurityIntegrationTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/config/WebSocketSecurityIntegrationTests.java
@@ -1,0 +1,134 @@
+package com.skkil.sync.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.skkil.sync.auth.AuthenticatedUser;
+import com.skkil.sync.common.config.TestcontainersConfig;
+import com.skkil.sync.user.constant.Role;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessageType;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.authorization.AuthorizationResult;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.messaging.web.csrf.CsrfChannelInterceptor;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * WebSocket은 나머지 테스트에서 꺼져 있다(application.yaml 기본값 false). 여기서만 켜서 브로커와 보안 설정이 실제로 조립되는지, 그리고 STOMP
+ * 프레임 인가 규칙 — 특히 목적지에 사용자 ID를 넣던 과거 방식(/topic/notifications/{id})이 기본 거부로 막히는지 — 를 검증한다.
+ */
+@Import(TestcontainersConfig.class)
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {"app.seed.enabled=false", "app.websocket.enabled=true"})
+class WebSocketSecurityIntegrationTests {
+
+  @Autowired private AuthorizationManager<Message<?>> messageAuthorizationManager;
+
+  @Autowired
+  @Qualifier("csrfChannelInterceptor")
+  private ChannelInterceptor csrfChannelInterceptor;
+
+  @Test
+  void csrfChannelInterceptor_isPlainComparisonVariant() {
+    // 빈 이름 "csrfChannelInterceptor"는 Spring Security가 기본 Xor 인터셉터의 교체
+    // 지점으로 조회하는 계약이다. csrf.spa()의 raw 토큰 방식과 맞추려면 평문 비교
+    // 인터셉터여야 하며, 이 단언이 깨지면 STOMP CONNECT가 전부 거부된다.
+    assertThat(csrfChannelInterceptor).isInstanceOf(CsrfChannelInterceptor.class);
+  }
+
+  @Test
+  void subscribeToUserQueue_isGrantedForAuthenticatedUser() {
+    AuthorizationResult result =
+        messageAuthorizationManager.authorize(
+            () -> authenticatedUser(1L), subscribeTo("/user/queue/notifications"));
+
+    assertThat(result).isNotNull();
+    assertThat(result.isGranted()).isTrue();
+  }
+
+  @Test
+  void subscribeToLegacyTopicDestination_isDeniedEvenForAuthenticatedUser() {
+    // 과거 취약 목적지 — 로그인한 사용자가 남의 알림 토픽을 구독할 수 있었다.
+    // 규칙에 없는 목적지이므로 기본 거부에 걸려야 한다.
+    AuthorizationResult result =
+        messageAuthorizationManager.authorize(
+            () -> authenticatedUser(1L), subscribeTo("/topic/notifications/2"));
+
+    assertThat(result).isNotNull();
+    assertThat(result.isGranted()).isFalse();
+  }
+
+  @Test
+  void subscribeToUserQueue_isDeniedForAnonymousUser() {
+    Authentication anonymous =
+        new AnonymousAuthenticationToken(
+            "key", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS"));
+
+    AuthorizationResult result =
+        messageAuthorizationManager.authorize(
+            () -> anonymous, subscribeTo("/user/queue/notifications"));
+
+    assertThat(result).isNotNull();
+    assertThat(result.isGranted()).isFalse();
+  }
+
+  @Test
+  void clientSendFrame_isDeniedEvenForAuthenticatedUser() {
+    // 살아 있는 @MessageMapping이 없으므로 클라이언트 발신 SEND 프레임은 전부 거부한다.
+    SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create(SimpMessageType.MESSAGE);
+    accessor.setDestination("/app/conversations/send");
+    Message<byte[]> send = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+    AuthorizationResult result =
+        messageAuthorizationManager.authorize(() -> authenticatedUser(1L), send);
+
+    assertThat(result).isNotNull();
+    assertThat(result.isGranted()).isFalse();
+  }
+
+  @Test
+  void connectFrame_isPermittedWithoutAuthentication() {
+    // CONNECT 자체는 허용한다 — 인증은 핸드셰이크(HTTP 세션)가, CSRF는 csrfChannelInterceptor가 맡는다.
+    SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create(SimpMessageType.CONNECT);
+    Message<byte[]> connect =
+        MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+    AuthorizationResult result = messageAuthorizationManager.authorize(() -> null, connect);
+
+    assertThat(result).isNotNull();
+    assertThat(result.isGranted()).isTrue();
+  }
+
+  private static Message<byte[]> subscribeTo(String destination) {
+    SimpMessageHeaderAccessor accessor =
+        SimpMessageHeaderAccessor.create(SimpMessageType.SUBSCRIBE);
+    accessor.setDestination(destination);
+    return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+  }
+
+  private static Authentication authenticatedUser(Long userId) {
+    AuthenticatedUser principal =
+        AuthenticatedUser.builder()
+            .userId(userId)
+            .fullName("사용자" + userId)
+            .email("user" + userId + "@example.com")
+            .role(Role.USER)
+            .enabled(true)
+            .build();
+    return UsernamePasswordAuthenticationToken.authenticated(
+        principal, null, principal.getAuthorities());
+  }
+}

--- a/apps/server/src/test/java/com/skkil/sync/notification/channel/InAppNotificationChannelTest.java
+++ b/apps/server/src/test/java/com/skkil/sync/notification/channel/InAppNotificationChannelTest.java
@@ -1,0 +1,47 @@
+package com.skkil.sync.notification.channel;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.skkil.sync.notification.constant.NotificationStatus;
+import com.skkil.sync.notification.constant.NotificationType;
+import com.skkil.sync.notification.dto.data.NotificationSummary;
+import com.skkil.sync.notification.model.NewFollowerPayload;
+import com.skkil.sync.user.model.User;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+class InAppNotificationChannelTest {
+
+  @Test
+  void send_publishesToUserDestinationKeyedByPrincipalName() {
+    SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
+    InAppNotificationChannel channel = new InAppNotificationChannel(messagingTemplate);
+    User recipient =
+        User.builder()
+            .email("recipient@example.com")
+            .fullName("수신자")
+            .hashedPassword("hash")
+            .build();
+    NotificationSummary notification =
+        new NotificationSummary(
+            1L,
+            NotificationType.NEW_FOLLOWER,
+            NotificationStatus.UNREAD,
+            Instant.parse("2026-01-01T00:00:00Z"),
+            null,
+            null,
+            null,
+            new NewFollowerPayload("follower", "팔로워"));
+
+    channel.send(recipient, notification);
+
+    // 목적지에 수신자 식별자가 들어가지 않고, 사용자 목적지의 키는 세션 Principal
+    // 이름(이메일)과 일치해야 한다. 둘 중 하나라도 어긋나면 알림이 조용히 유실된다.
+    // 목적지 문자열은 웹 클라이언트가 구독하는 /user/queue/notifications와의 계약이므로
+    // 프로덕션 상수를 재사용하지 않고 리터럴로 단언한다.
+    verify(messagingTemplate)
+        .convertAndSendToUser("recipient@example.com", "/queue/notifications", notification);
+  }
+}

--- a/apps/server/src/test/java/com/skkil/sync/notification/service/NotificationProcessorServiceTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/notification/service/NotificationProcessorServiceTests.java
@@ -1,0 +1,111 @@
+package com.skkil.sync.notification.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.skkil.sync.media.service.domain.MediaDomainService;
+import com.skkil.sync.notification.channel.NotificationChannel;
+import com.skkil.sync.notification.constant.ChannelType;
+import com.skkil.sync.notification.constant.NotificationStatus;
+import com.skkil.sync.notification.constant.NotificationType;
+import com.skkil.sync.notification.dto.data.NotificationSummary;
+import com.skkil.sync.notification.event.NotificationEvent;
+import com.skkil.sync.notification.mapper.NotificationMapper;
+import com.skkil.sync.notification.model.NewFollowerPayload;
+import com.skkil.sync.notification.model.Notification;
+import com.skkil.sync.notification.repository.NotificationRepository;
+import com.skkil.sync.user.model.User;
+import com.skkil.sync.user.service.domain.UserDomainService;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationProcessorServiceTests {
+
+  @Mock private NotificationPreferencesService notificationPreferencesService;
+  @Mock private NotificationRepository notificationRepository;
+  @Mock private UserDomainService userDomainService;
+  @Mock private NotificationMapper notificationMapper;
+  @Mock private MediaDomainService mediaDomainService;
+
+  /** 프로덕션은 WebSocket이 꺼져 있어 채널 빈이 하나도 없다. 그 상태에서도 알림은 저장돼야 한다 — 이 강등 경로가 프로덕션이 실제로 쓰는 유일한 경로다. */
+  @Test
+  void handleNotificationEvent_withoutAnyChannel_stillPersistsNotification() {
+    NotificationProcessorService service = serviceWithChannels(List.of());
+    stubRecipient();
+
+    service.handleNotificationEvent(newFollowerEventTo(1L));
+
+    verify(notificationRepository).save(any(Notification.class));
+  }
+
+  @Test
+  void handleNotificationEvent_withInAppChannel_pushesToRecipient() {
+    NotificationChannel inAppChannel = mock(NotificationChannel.class);
+    when(inAppChannel.type()).thenReturn(ChannelType.IN_APP);
+    NotificationProcessorService service = serviceWithChannels(List.of(inAppChannel));
+    User recipient = stubRecipient();
+    NotificationSummary summary =
+        new NotificationSummary(
+            1L,
+            NotificationType.NEW_FOLLOWER,
+            NotificationStatus.UNREAD,
+            Instant.parse("2026-01-01T00:00:00Z"),
+            null,
+            null,
+            null,
+            new NewFollowerPayload("follower", "팔로워"));
+    when(notificationMapper.toDto(any(Notification.class), anyMap())).thenReturn(summary);
+
+    service.handleNotificationEvent(newFollowerEventTo(1L));
+
+    // 채널이 받는 수신자는 저장된 알림의 사용자여야 한다 — 사용자 목적지의
+    // 키(이메일)가 여기서 나오므로, 다른 User가 넘어가면 알림이 엉뚱한 사람에게 간다.
+    verify(inAppChannel).send(same(recipient), eq(summary));
+  }
+
+  private NotificationProcessorService serviceWithChannels(List<NotificationChannel> channels) {
+    return new NotificationProcessorService(
+        notificationPreferencesService,
+        notificationRepository,
+        userDomainService,
+        notificationMapper,
+        mediaDomainService,
+        channels);
+  }
+
+  private User stubRecipient() {
+    User recipient =
+        User.builder()
+            .email("recipient@example.com")
+            .fullName("수신자")
+            .hashedPassword("hash")
+            .build();
+    when(notificationPreferencesService.isInAppEnabled(1L)).thenReturn(true);
+    when(userDomainService.getUserReference(1L)).thenReturn(recipient);
+    when(notificationMapper.toPayloadJson(any())).thenReturn(JsonNodeFactory.instance.objectNode());
+    when(notificationRepository.save(any(Notification.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    return recipient;
+  }
+
+  private static NotificationEvent newFollowerEventTo(Long recipientId) {
+    return new NotificationEvent(
+        recipientId,
+        NotificationType.NEW_FOLLOWER,
+        null,
+        null,
+        null,
+        new NewFollowerPayload("follower", "팔로워"));
+  }
+}

--- a/apps/web/src/components/feature/notification/hooks/useNotifications.ts
+++ b/apps/web/src/components/feature/notification/hooks/useNotifications.ts
@@ -20,8 +20,9 @@ const WEBSOCKET_ENABLED = process.env.NEXT_PUBLIC_WEBSOCKET_ENABLED === 'true';
  * 드롭다운 미리보기와 전체 알림 페이지가 동일한 구독 로직을 공유한다.
  *
  * WebSocket이 꺼져 있으면 구독을 건너뛴다. `subscribe`는 클라이언트가 연결되지
- * 않았을 때 오류 토스트를 띄우는데, 설정으로 꺼둔 상태는 오류가 아니며 이때는
- * 폴링으로 알림을 가져온다.
+ * 않았을 때 오류 토스트를 띄우는데, 설정으로 꺼둔 상태는 오류가 아니다. 이때
+ * 실시간 갱신은 없으며 쿼리가 다시 실행되는 시점(마운트·무효화)에만 목록을
+ * 가져온다.
  */
 export function useNotifications(params: GetNotificationsParams) {
   const { page, size } = params;
@@ -38,39 +39,38 @@ export function useNotifications(params: GetNotificationsParams) {
       return;
     }
 
-    const subscription = subscribe(
-      `/topic/notifications/${session.user.id}`,
-      (message) => {
-        const notification = JSON.parse(
-          message.body,
-        ) as GetNotificationsResponseNotificationsContentItem;
+    // 사용자 목적지 — 브로커가 세션별로 해소하므로 목적지에 사용자 ID를 넣지
+    // 않는다. ID가 든 공개 토픽은 남의 알림을 구독할 수 있어 서버에서 거부된다.
+    const subscription = subscribe('/user/queue/notifications', (message) => {
+      const notification = JSON.parse(
+        message.body,
+      ) as GetNotificationsResponseNotificationsContentItem;
 
-        queryClient.setQueryData<{ data: GetNotificationsResponse }>(
-          getGetNotificationsQueryKey({ page, size }),
-          (old) => {
-            if (!old) {
-              return old;
-            }
+      queryClient.setQueryData<{ data: GetNotificationsResponse }>(
+        getGetNotificationsQueryKey({ page, size }),
+        (old) => {
+          if (!old) {
+            return old;
+          }
 
-            const previous = old.data.notifications;
+          const previous = old.data.notifications;
 
-            return {
-              ...old,
-              data: {
-                ...old.data,
-                unreadCount: old.data.unreadCount + 1,
-                notifications: previous
-                  ? {
-                      ...previous,
-                      content: [notification, ...(previous.content ?? [])],
-                    }
-                  : previous,
-              },
-            };
-          },
-        );
-      },
-    );
+          return {
+            ...old,
+            data: {
+              ...old.data,
+              unreadCount: old.data.unreadCount + 1,
+              notifications: previous
+                ? {
+                    ...previous,
+                    content: [notification, ...(previous.content ?? [])],
+                  }
+                : previous,
+            },
+          };
+        },
+      );
+    });
 
     return () => {
       subscription?.unsubscribe();

--- a/apps/web/src/lib/ws.ts
+++ b/apps/web/src/lib/ws.ts
@@ -1,7 +1,7 @@
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
 
-import { isServer } from '@/util/server';
+import { getCsrfToken, isServer } from '@/util/server';
 
 import { env } from './env';
 
@@ -22,9 +22,20 @@ export function getStompClient(): Client {
     webSocketFactory: () => {
       return new SockJS(url);
     },
+    // 서버가 STOMP CONNECT 프레임에서 CSRF 토큰을 검증한다(HTTP 요청과 동일한
+    // X-XSRF-TOKEN 헤더). 토큰이 회전될 수 있으므로 재연결마다 새로 읽는다.
+    beforeConnect: async (stompClient) => {
+      const csrfToken = await getCsrfToken();
+      if (csrfToken) {
+        stompClient.connectHeaders = { 'X-XSRF-TOKEN': csrfToken };
+      }
+    },
+    // 프레임에 알림 payload가 그대로 담기므로 프로덕션 콘솔에는 남기지 않는다.
     debug: (message) => {
-      // eslint-disable-next-line no-console -- intentional STOMP protocol debug logging, pre-existing
-      console.log(`[STOMP] ${message}`);
+      if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console -- intentional STOMP protocol debug logging, pre-existing
+        console.log(`[STOMP] ${message}`);
+      }
     },
     reconnectDelay: 5000,
     heartbeatIncoming: 4000,


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 버그 수정 (보안)
- Related Issue: 없음

로그인한 사용자가 `/topic/notifications/{userId}`를 구독해 **남의 알림을 실시간 수신할 수 있는** 결함을 수정합니다. STOMP 프레임(SUBSCRIBE/SEND)은 HTTP 필터 체인을 타지 않는데, 브로커에 메시지 레벨 인가가 전혀 없어 알림 payload(댓글·팔로우·비공개 프로젝트 초대 토큰 포함)가 통째로 노출되는 구조였습니다.

**프로덕션은 `WEBSOCKET_ENABLED=false`라 현재 런타임 동작 변화가 없습니다.** 이 PR은 WebSocket을 켜기 전 반드시 머지되어야 하는 선행 조건입니다.

주요 변경:

- **`WebSocketSecurityConfig` 신규** — `@EnableWebSocketSecurity` + 기본 거부 메시지 인가. `/user/queue/notifications` SUBSCRIBE만 인증 사용자에게 허용, 규칙에 없는 목적지·프레임은 전부 거부
- **사용자 목적지 전환** — `convertAndSendToUser(email, "/queue/notifications", …)`로 발행하고 브로커에서 `/topic`을 제거. 목적지 문자열에 사용자 식별자가 사라져 같은 실수가 구조적으로 불가능. 목적지 키는 세션 Principal 이름(이메일, `AuthenticatedUser.getName()`)과 일치 — 세션 무효화가 이메일로 조회하는 것과 같은 계약
- **STOMP CONNECT CSRF** — 기본 `XorCsrfChannelInterceptor`는 XOR 마스킹 토큰만 받아 `csrf.spa()`의 raw 쿠키 방식과 맞지 않으므로, 평문 비교 `CsrfChannelInterceptor`를 `csrfChannelInterceptor` 빈으로 교체(Security 7.0.2 소스로 빈 이름 계약 확인). SockJS 폴백 전송(xhr_send 등 POST)은 커스텀 헤더를 실을 수 없어 HTTP CSRF에 막히므로 `/ws/**`를 예외 처리 — Origin 허용 목록 + 프레임 레벨 검증이 대신 보호 (Spring Security 공식 문서의 SockJS 권장 구성)
- **웹** — `/user/queue/notifications` 구독, `beforeConnect`에서 `X-XSRF-TOKEN`을 CONNECT 헤더에 주입, 프로덕션 콘솔에 알림 payload가 찍히던 STOMP 디버그 로깅 차단

## PR Checklist

- [x] 코드가 정상적으로 빌드되었나요? (`./gradlew build` 성공, 웹 `lint`/`tsc --noEmit`/`build` 통과, `openapi3.yaml` 무변경)
- [x] 적절한 테스트 코드가 추가되었나요? 추가되었다면 아래에 어떤 테스트인지 설명해 주세요.
  - [x] `WebSocketSecurityIntegrationTests` (6건) — WS를 켠 컨텍스트가 실제로 조립되는지(이 저장소에서 처음 검증되는 경로) + 인가 규칙: 자기 사용자 목적지 허용, **과거 취약 목적지 `/topic/notifications/{id}` 거부**, 익명 거부, SEND 거부, CONNECT 허용, CSRF 인터셉터 빈 계약
  - [x] `InAppNotificationChannelTest` — 발행 목적지·Principal 키(이메일) 계약을 리터럴로 단언 (상수 재사용 시 자기참조 통과 방지)
  - [x] `NotificationProcessorServiceTests` (2건) — 채널 빈이 없을 때도 알림 저장 유지(프로덕션이 실제로 쓰는 강등 경로) + 채널 존재 시 저장된 알림의 수신자에게 push
- [ ] 리뷰어 설정이 완료되었나요?

## Other

### 참고사항

이번 범위에서 제외한, 리뷰 과정에서 확인된 기존 결함 3건 (WebSocket을 켜기 전 별도 처리 권장):

1. **세션 무효화가 살아있는 STOMP 연결에 전파되지 않음** — 비밀번호 변경/재설정이 JDBC 세션만 삭제하고 열린 WS 연결은 끊지 못해, 탈취된 세션으로 먼저 연결한 공격자는 계속 알림을 수신. `SessionInvalidationService`에서 WS 세션 강제 종료 필요 (spring-session 통합은 JDBC 삭제가 `SessionDestroyedEvent`를 발행하지 않아 효과 없음)
2. **재연결 시 재구독 부재** — `WebSocketProvider.subscribe`가 연결 전이면 실패하고, 재연결 후 자동 재구독이 없음
3. **WS 푸시가 트랜잭션 커밋 전에 발생** — 롤백 시 유령 알림 가능성

WebSocket을 실제로 켜는 작업(인프라 3종: `deploy.sh`, nginx `/ws` location + Upgrade 헤더, 웹 Dockerfile `NEXT_PUBLIC_WEBSOCKET_ENABLED` ARG)도 이 PR에 포함하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)