### PR TITLE
fix: 알림 푸시를 커밋 이후로 이동하고 아바타 서명 실패를 격리

### DIFF
--- a/apps/server/src/main/java/com/skkil/sync/config/AsyncConfig.java
+++ b/apps/server/src/main/java/com/skkil/sync/config/AsyncConfig.java
@@ -1,5 +1,6 @@
 package com.skkil.sync.config;
 
+import java.util.Arrays;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -69,12 +70,15 @@ public class AsyncConfig implements AsyncConfigurer {
 
   @Override
   public @Nullable AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
-    return (throwable, method, objects) -> {
-      log.error("Exception message - " + throwable.getMessage());
-      log.info("Method name - " + method.getName());
-      for (Object param : objects) {
-        log.info("Parameter value - " + param);
-      }
-    };
+    // Throwable을 SLF4J 마지막 인자로 넘겨야 스택트레이스와 cause 체인이 남는다.
+    // 메시지만 이어 붙이면 알림·이메일 등 모든 @Async 실패가 한 줄로 축약되어
+    // 원인 추적이 불가능해진다.
+    return (throwable, method, objects) ->
+        log.error(
+            "비동기 메서드 {}.{} 실행 실패 (인자: {})",
+            method.getDeclaringClass().getSimpleName(),
+            method.getName(),
+            Arrays.toString(objects),
+            throwable);
   }
 }

--- a/apps/server/src/main/java/com/skkil/sync/media/service/domain/MediaDomainService.java
+++ b/apps/server/src/main/java/com/skkil/sync/media/service/domain/MediaDomainService.java
@@ -194,4 +194,40 @@ public class MediaDomainService {
 
     return result;
   }
+
+  /**
+   * {@link #generatePresignedGetUrls(List, Function)}의 관대한 변형 — 서명에 실패한 미디어는 결과에서 빼고 계속 간다.
+   *
+   * <p>미디어 URL이 본질이 아닌 소비자(예: 알림의 행위자 아바타)를 위한 것이다. strict 버전은 한 건의 실패가 예외로 전파되는데, 호출자가 쓰기 트랜잭션이면
+   * 참여-실패 규칙에 따라 공유 트랜잭션이 rollback-only로 표시된다 — 호출부 try/catch로는 지울 수 없어 본체 저장까지 함께 사라진다. 여기서는 예외가 이
+   * 메서드 경계를 벗어나지 않으므로 그 표시 자체가 생기지 않는다.
+   *
+   * <p>의도적으로 {@code @Transactional}이 없다: 이 메서드는 DB를 읽지 않고(엔티티는 호출자가 이미 로드했고 서명은 로컬 연산이다), 커밋 완료 후의
+   * {@code afterCommit} 콜백에서도 호출되는데 그 시점의 트랜잭션 프록시 진입은 "커밋이 뒤따르지 않는 참여"가 되어 Spring이 금지하는 패턴이다
+   * ({@code TransactionSynchronization#afterCommit} 계약 참고). 프록시가 없으면 그 문제 자체가 생기지 않는다.
+   *
+   * <p>S3 서명은 자격증명 체인 해소(EC2 IMDS) 때문에 네트워크 장애로도 실패할 수 있다 — 미디어 상태가 정상이어도 안전하지 않다.
+   */
+  public <T> Map<Long, URL> generatePresignedGetUrlsLenient(
+      List<T> items, Function<T, Media> mediaExtractor) {
+    Map<Long, URL> result = new HashMap<>();
+    for (T item : items) {
+      if (item == null) {
+        continue;
+      }
+
+      Media media = mediaExtractor.apply(item);
+      if (media == null) {
+        continue;
+      }
+
+      try {
+        result.put(media.getId(), generatePresignedGetUrl(media));
+      } catch (RuntimeException exception) {
+        log.warn("미디어 {} 서명 실패 — URL 없이 진행한다.", media.getId(), exception);
+      }
+    }
+
+    return result;
+  }
 }

--- a/apps/server/src/main/java/com/skkil/sync/notification/event/NotificationEvent.java
+++ b/apps/server/src/main/java/com/skkil/sync/notification/event/NotificationEvent.java
@@ -5,10 +5,17 @@ import com.skkil.sync.notification.constant.NotificationType;
 import com.skkil.sync.notification.model.NotificationPayload;
 import java.util.Objects;
 import lombok.Getter;
+import lombok.ToString;
 import org.jspecify.annotations.Nullable;
 import org.springframework.context.ApplicationEvent;
 
+/**
+ * {@code toString}은 비동기 처리 실패 로그에 그대로 실린다 — 기본 {@code EventObject} 폴백은 수신자 ID만 남겨 유실된 알림을 재구성할 수
+ * 없으므로, 타입·행위자·대상까지 로그에서 복원 가능하도록 필드를 노출한다. 단 payload는 제외한다: 초대 payload의 토큰처럼 로그에 남기면 안 되는 값이 들어
+ * 있고, 재구성에는 타입·수신자·entity 식별자만으로 충분하다.
+ */
 @Getter
+@ToString
 public class NotificationEvent extends ApplicationEvent {
 
   private final Long recipientId;
@@ -16,7 +23,8 @@ public class NotificationEvent extends ApplicationEvent {
   private final @Nullable Long actorId;
   private final @Nullable NotificationEntityType entityType;
   private final @Nullable Long entityId;
-  private final NotificationPayload payload;
+
+  @ToString.Exclude private final NotificationPayload payload;
 
   public NotificationEvent(
       Long recipientId,

--- a/apps/server/src/main/java/com/skkil/sync/notification/service/NotificationProcessorService.java
+++ b/apps/server/src/main/java/com/skkil/sync/notification/service/NotificationProcessorService.java
@@ -16,11 +16,14 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Hibernate;
 import org.jspecify.annotations.Nullable;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @Slf4j
@@ -49,6 +52,15 @@ public class NotificationProcessorService {
         channels.stream().collect(Collectors.toMap(NotificationChannel::type, Function.identity()));
   }
 
+  /**
+   * 저장은 이 트랜잭션에서 확정하고, 푸시는 커밋 이후에 best-effort로 보낸다.
+   *
+   * <p>커밋 전에 푸시하면 두 가지가 깨진다. 하나는 순서 — 아직 커밋되지 않은 알림을 클라이언트가 받아 되조회하면 없다. 다른 하나가 더 무겁다: 푸시 경로(DTO
+   * 조립·S3 서명·직렬화)에서 난 예외가 아무에게도 잡히지 않으면 이미 INSERT된 알림까지 롤백되어 영구 소실된다 — 재발행 경로가 없다. 그렇다고 트랜잭션 안에서
+   * try/catch로 감싸면, 참여 중인 {@code @Transactional} 빈이 던진 예외가 공유 트랜잭션을 rollback-only로 표시해 커밋이 {@code
+   * UnexpectedRollbackException}으로 끝난다 — 표시는 호출부 catch로 지울 수 없다. 커밋 뒤로 옮기면 표시할 트랜잭션 자체가 없으므로 두 경로가
+   * 함께 닫힌다.
+   */
   @Async
   @EventListener
   @Transactional
@@ -71,8 +83,42 @@ public class NotificationProcessorService {
       return;
     }
 
-    log.debug("Sending notification {} via channel {}", notification.getId(), ChannelType.IN_APP);
-    channel.send(notification.getUser(), toDto(notification));
+    // afterCommit 시점에도 EntityManager는 열려 있지만(정리는 그 다음 단계),
+    // 그때의 지연 로딩은 끝난 트랜잭션 밖에서 커넥션을 새로 잡는다. 푸시에 필요한
+    // 연관은 트랜잭션 안에서 미리 초기화해 콜백을 DB-free로 만든다.
+    warmUpForPush(notification.getUser(), notification.getActor());
+
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.registerSynchronization(
+          new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+              push(channel, notification);
+            }
+          });
+    } else {
+      // 트랜잭션 밖 호출(단위 테스트 등) — 지킬 커밋이 없으므로 그 자리에서 푸시한다.
+      push(channel, notification);
+    }
+  }
+
+  private void push(NotificationChannel channel, Notification notification) {
+    try {
+      log.debug("Sending notification {} via channel {}", notification.getId(), ChannelType.IN_APP);
+      channel.send(notification.getUser(), toDto(notification));
+    } catch (RuntimeException exception) {
+      // 알림은 이미 커밋됐다. 푸시만 실패한 것이므로 수신자는 목록 조회로 볼 수 있다.
+      log.warn(
+          "알림 {} 는 저장됐지만 실시간 푸시에 실패했다 — 수신자는 목록 조회로 확인할 수 있다.", notification.getId(), exception);
+    }
+  }
+
+  private void warmUpForPush(User recipient, @Nullable User actor) {
+    Hibernate.initialize(recipient);
+    if (actor != null) {
+      Hibernate.initialize(actor);
+      Hibernate.initialize(actor.getProfileImage());
+    }
   }
 
   private Notification createNotification(NotificationEvent event) {
@@ -102,6 +148,9 @@ public class NotificationProcessorService {
       return Map.of();
     }
 
-    return mediaDomainService.generatePresignedGetUrls(List.of(actor), User::getProfileImage);
+    // 아바타 URL은 있으면 좋은 장식이다 — 서명 실패가 푸시 자체를 막지 않도록
+    // 관대한 변형을 쓴다. 매퍼는 URL이 없으면 null로 내려보낸다.
+    return mediaDomainService.generatePresignedGetUrlsLenient(
+        List.of(actor), User::getProfileImage);
   }
 }

--- a/apps/server/src/main/java/com/skkil/sync/notification/service/NotificationService.java
+++ b/apps/server/src/main/java/com/skkil/sync/notification/service/NotificationService.java
@@ -40,8 +40,10 @@ public class NotificationService {
         paginationService.paginate(
             pageable -> notificationRepository.findByUser(userId, pageable), pagination);
 
+    // 페이지 전체를 한 번에 서명하므로, strict 버전이면 아바타 한 건의 실패가
+    // 알림 목록 전체를 404로 만든다. 아바타는 장식이니 실패분만 빼고 내려보낸다.
     var actorProfileImageUrls =
-        mediaDomainService.generatePresignedGetUrls(
+        mediaDomainService.generatePresignedGetUrlsLenient(
             page.content(),
             notification -> {
               var actor = notification.getActor();

--- a/apps/server/src/test/java/com/skkil/sync/media/service/domain/MediaDomainServiceTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/media/service/domain/MediaDomainServiceTests.java
@@ -3,6 +3,7 @@ package com.skkil.sync.media.service.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import com.skkil.sync.media.enums.MediaStatus;
@@ -15,7 +16,13 @@ import com.skkil.sync.media.model.Media;
 import com.skkil.sync.media.repository.MediaRepository;
 import com.skkil.sync.user.model.User;
 import io.awspring.cloud.s3.S3Template;
+import java.net.URI;
+import java.net.URL;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -126,6 +133,49 @@ class MediaDomainServiceTests {
 
     assertThatThrownBy(() -> service().linkMedia(UPLOADER_ID, MEDIA_ID))
         .isInstanceOf(MediaNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("[generatePresignedGetUrlsLenient] 서명에 실패한 미디어만 빼고 계속 간다")
+  void generatePresignedGetUrlsLenient_skipsFailedItems() throws Exception {
+    Media healthy = uploadedMedia(10L, "healthy-key");
+    Media broken = uploadedMedia(11L, "broken-key");
+    URL url = URI.create("https://cdn.example.com/healthy").toURL();
+    when(s3Template.createSignedGetURL(eq("test-bucket"), eq("healthy-key"), any(Duration.class)))
+        .thenReturn(url);
+    when(s3Template.createSignedGetURL(eq("test-bucket"), eq("broken-key"), any(Duration.class)))
+        .thenThrow(new IllegalStateException("자격증명 해소 실패"));
+
+    Map<Long, URL> result =
+        service().generatePresignedGetUrlsLenient(List.of(healthy, broken), Function.identity());
+
+    assertThat(result).containsOnlyKeys(10L).containsEntry(10L, url);
+  }
+
+  @Test
+  @DisplayName("[generatePresignedGetUrlsLenient] UPLOADED가 아닌 미디어도 예외 없이 건너뛴다")
+  void generatePresignedGetUrlsLenient_skipsNonUploadedMedia() {
+    Media pending = givenPendingMedia("image/png", 1024L);
+
+    Map<Long, URL> result =
+        service().generatePresignedGetUrlsLenient(List.of(pending), Function.identity());
+
+    assertThat(result).isEmpty();
+  }
+
+  private Media uploadedMedia(Long id, String key) {
+    Media media =
+        Media.builder()
+            .uploader(new User(UPLOADER_ID))
+            .mediaType("image/png")
+            .bucket("test-bucket")
+            .key(key)
+            .fileName("test-file")
+            .fileSize(1024L)
+            .build();
+    media.setId(id);
+    media.markAsUploaded();
+    return media;
   }
 
   private MediaDomainService service() {

--- a/apps/server/src/test/java/com/skkil/sync/notification/service/NotificationProcessorServiceTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/notification/service/NotificationProcessorServiceTests.java
@@ -1,10 +1,13 @@
 package com.skkil.sync.notification.service;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -72,6 +75,47 @@ class NotificationProcessorServiceTests {
     // 채널이 받는 수신자는 저장된 알림의 사용자여야 한다 — 사용자 목적지의
     // 키(이메일)가 여기서 나오므로, 다른 User가 넘어가면 알림이 엉뚱한 사람에게 간다.
     verify(inAppChannel).send(same(recipient), eq(summary));
+  }
+
+  /** 소실 회귀: DTO 조립(presign) 실패가 저장을 되돌리거나 호출자에게 전파되면 안 된다. 푸시는 best-effort이고, 알림 저장이 항상 우선한다. */
+  @Test
+  void handleNotificationEvent_presignFailure_keepsSaveAndDoesNotPropagate() {
+    NotificationChannel inAppChannel = mock(NotificationChannel.class);
+    when(inAppChannel.type()).thenReturn(ChannelType.IN_APP);
+    NotificationProcessorService service = serviceWithChannels(List.of(inAppChannel));
+    stubRecipient();
+    User actor =
+        User.builder().email("actor@example.com").fullName("행위자").hashedPassword("hash").build();
+    when(userDomainService.getUserReference(2L)).thenReturn(actor);
+    when(mediaDomainService.generatePresignedGetUrlsLenient(anyList(), any()))
+        .thenThrow(new IllegalStateException("S3 자격증명 해소 실패"));
+
+    NotificationEvent event =
+        new NotificationEvent(
+            1L,
+            NotificationType.NEW_FOLLOWER,
+            2L,
+            null,
+            null,
+            new NewFollowerPayload("follower", "팔로워"));
+
+    assertThatCode(() -> service.handleNotificationEvent(event)).doesNotThrowAnyException();
+
+    verify(notificationRepository).save(any(Notification.class));
+    verify(inAppChannel, never()).send(any(), any());
+  }
+
+  @Test
+  void handleNotificationEvent_notificationsDisabled_skipsSaveAndPush() {
+    NotificationChannel inAppChannel = mock(NotificationChannel.class);
+    when(inAppChannel.type()).thenReturn(ChannelType.IN_APP);
+    NotificationProcessorService service = serviceWithChannels(List.of(inAppChannel));
+    when(notificationPreferencesService.isInAppEnabled(1L)).thenReturn(false);
+
+    service.handleNotificationEvent(newFollowerEventTo(1L));
+
+    verify(notificationRepository, never()).save(any(Notification.class));
+    verify(inAppChannel, never()).send(any(), any());
   }
 
   private NotificationProcessorService serviceWithChannels(List<NotificationChannel> channels) {

--- a/apps/server/src/test/java/com/skkil/sync/notification/service/NotificationPushResilienceIntegrationTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/notification/service/NotificationPushResilienceIntegrationTests.java
@@ -1,0 +1,228 @@
+package com.skkil.sync.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.skkil.sync.common.config.TestcontainersConfig;
+import com.skkil.sync.common.util.pagination.dto.request.OffsetPaginationRequest;
+import com.skkil.sync.media.model.Media;
+import com.skkil.sync.media.repository.MediaRepository;
+import com.skkil.sync.notification.channel.NotificationChannel;
+import com.skkil.sync.notification.constant.ChannelType;
+import com.skkil.sync.notification.constant.NotificationStatus;
+import com.skkil.sync.notification.constant.NotificationType;
+import com.skkil.sync.notification.dto.data.NotificationSummary;
+import com.skkil.sync.notification.dto.response.GetNotificationsResponse;
+import com.skkil.sync.notification.event.NotificationEvent;
+import com.skkil.sync.notification.model.NewFollowerPayload;
+import com.skkil.sync.notification.repository.NotificationRepository;
+import com.skkil.sync.user.model.User;
+import com.skkil.sync.user.repository.UserRepository;
+import io.awspring.cloud.s3.S3Template;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * 알림 저장과 실시간 푸시의 순서·격리를 실제 트랜잭션과 실제 빈 위에서 검증한다.
+ *
+ * <p>저장은 커밋으로 확정되고 푸시는 그 이후의 best-effort여야 한다 — S3 서명이나 채널 전송이 실패해도 알림 행은 살아남아야 한다. 과거 구조(커밋 전 푸시,
+ * 단일 트랜잭션)에서는 서명·전송 예외가 INSERT까지 함께 롤백시켜 이 테스트들이 실패한다.
+ *
+ * <p>{@code MediaDomainService}는 모킹하지 않는다 — 서명 실패는 그 아래의 {@link S3Template}에서 일으켜, 관대한 서명 경로가 실제
+ * 코드로 실행되게 한다.
+ */
+@Import({
+  TestcontainersConfig.class,
+  NotificationPushResilienceIntegrationTests.ChannelConfig.class
+})
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {"app.seed.enabled=false", "app.websocket.enabled=false"})
+class NotificationPushResilienceIntegrationTests {
+
+  @Autowired private ApplicationEventPublisher eventPublisher;
+  @Autowired private NotificationRepository notificationRepository;
+  @Autowired private UserRepository userRepository;
+  @Autowired private MediaRepository mediaRepository;
+  @Autowired private NotificationService notificationService;
+  @Autowired private RecordingChannel recordingChannel;
+
+  @MockitoBean private S3Template s3Template;
+
+  private User recipient;
+  private User actor;
+
+  @BeforeEach
+  void setUp() {
+    recordingChannel.reset();
+    recipient = saveUser("push-recipient");
+    actor = saveUser("push-actor");
+  }
+
+  @Test
+  @DisplayName("S3 서명이 실패해도 알림 행은 커밋되고 푸시는 URL 없이 나간다")
+  void presignFailure_notificationPersistedAndPushedWithoutUrl() {
+    givenActorAvatar();
+    when(s3Template.createSignedGetURL(anyString(), anyString(), any(Duration.class)))
+        .thenThrow(new IllegalStateException("IMDS 자격증명 해소 실패 시뮬레이션"));
+
+    eventPublisher.publishEvent(newFollowerEvent());
+
+    awaitUnreadCount(1);
+    await("푸시 도착", () -> pushesToRecipient() == 1);
+
+    // 읽기 경로도 같은 장애에서 살아남아야 한다 — 아바타 한 건의 서명 실패가
+    // 알림 목록 전체를 실패시키면 안 된다.
+    GetNotificationsResponse response =
+        notificationService.getNotifications(recipient.getId(), new OffsetPaginationRequest(0, 20));
+    assertThat(response.notifications().content()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("실시간 푸시가 실패해도 알림 행은 커밋된다")
+  void pushFailure_notificationStillPersisted() {
+    recordingChannel.failNextSend();
+
+    eventPublisher.publishEvent(newFollowerEvent());
+
+    awaitUnreadCount(1);
+    await("푸시 시도", () -> pushesToRecipient() == 1);
+  }
+
+  @Test
+  @DisplayName("정상 경로에서는 저장 후 수신자에게 푸시된다")
+  void happyPath_persistsThenPushes() {
+    eventPublisher.publishEvent(newFollowerEvent());
+
+    awaitUnreadCount(1);
+    await("푸시 도착", () -> pushesToRecipient() == 1);
+  }
+
+  private void givenActorAvatar() {
+    Media avatar =
+        Media.builder()
+            .uploader(actor)
+            .mediaType("image/png")
+            .bucket("test-bucket")
+            .key("avatar-" + System.nanoTime())
+            .fileName("avatar.png")
+            .fileSize(1024L)
+            .build();
+    avatar.markAsUploaded();
+    mediaRepository.save(avatar);
+    actor.setProfileImage(avatar);
+    actor = userRepository.save(actor);
+  }
+
+  private NotificationEvent newFollowerEvent() {
+    return new NotificationEvent(
+        recipient.getId(),
+        NotificationType.NEW_FOLLOWER,
+        actor.getId(),
+        null,
+        null,
+        new NewFollowerPayload("follower", "팔로워"));
+  }
+
+  private User saveUser(String prefix) {
+    return userRepository.save(
+        User.builder()
+            .email(prefix + "-" + System.nanoTime() + "@example.com")
+            .fullName("알림 테스트")
+            .hashedPassword("hash")
+            .build());
+  }
+
+  /** 이전 테스트의 비동기 잔류 푸시가 섞이지 않도록, 이 테스트의 수신자 분만 센다. */
+  private long pushesToRecipient() {
+    return recordingChannel.recipientEmails().stream()
+        .filter(email -> email.equals(recipient.getEmail()))
+        .count();
+  }
+
+  private void awaitUnreadCount(long expected) {
+    await(
+        "알림 저장",
+        () ->
+            notificationRepository.countByUser_IdAndStatus(
+                    recipient.getId(), NotificationStatus.UNREAD)
+                == expected);
+  }
+
+  /** 비동기({@code @Async}) 처리 완료를 폴링으로 기다린다 (Awaitility 미도입). */
+  private static void await(String what, BooleanSupplier condition) {
+    Instant deadline = Instant.now().plusSeconds(10);
+    while (Instant.now().isBefore(deadline)) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      try {
+        Thread.sleep(50);
+      } catch (InterruptedException interrupted) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException(interrupted);
+      }
+    }
+    throw new AssertionError(what + " 대기가 10초 안에 끝나지 않았다");
+  }
+
+  @TestConfiguration
+  static class ChannelConfig {
+
+    /** WebSocket 플래그와 무관하게 IN_APP 채널을 공급해 커밋-후-푸시 경로를 실행시킨다. */
+    @Bean
+    RecordingChannel recordingChannel() {
+      return new RecordingChannel();
+    }
+  }
+
+  static class RecordingChannel implements NotificationChannel {
+
+    private final AtomicBoolean failNextSend = new AtomicBoolean();
+    private final List<String> recipientEmails = new CopyOnWriteArrayList<>();
+
+    @Override
+    public ChannelType type() {
+      return ChannelType.IN_APP;
+    }
+
+    @Override
+    public void send(User recipient, NotificationSummary notification) {
+      recipientEmails.add(recipient.getEmail());
+      if (failNextSend.getAndSet(false)) {
+        throw new IllegalStateException("브로커 전송 실패 시뮬레이션");
+      }
+    }
+
+    void failNextSend() {
+      failNextSend.set(true);
+    }
+
+    List<String> recipientEmails() {
+      return List.copyOf(recipientEmails);
+    }
+
+    void reset() {
+      failNextSend.set(false);
+      recipientEmails.clear();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 버그 수정
- Related Issue: 없음

WebSocket을 켜는 순간 무장되는 **알림 영구 소실 경로**를 제거합니다. #220/#221에 이은 WS 활성화 선행 조건 시리즈의 서버측 마지막 조각입니다.

**문제.** `NotificationProcessorService`가 저장·DTO 조립(S3 presign)·푸시를 한 트랜잭션에서 수행했습니다:

| 방향 | 시나리오 | 결과 |
| --- | --- | --- |
| 소실 (major) | presign 예외(S3 자격증명은 EC2 IMDS 해소라 네트워크 장애로 실패 가능 — 프로덕션 `server.env`에 정적 자격증명 없음) | 이미 INSERT된 알림까지 롤백, **영구 소실**. 재발행 경로 없음. 장애 창에서는 그 창의 알림이 뭉텅이로 사라짐 |
| 유령 (minor) | 푸시 후 커밋 실패 | 클라이언트만 알림 보유. 클릭 시 404가 무음 처리됨 |
| 읽기 (오늘도 유효) | `GET /notifications`가 페이지 전체를 한 번에 presign | 아바타 **한 건**의 서명 실패가 알림 목록 전체를 404로 |

트랜잭션 안 `try/catch`는 해법이 아닙니다 — 참여 `@Transactional` 빈의 예외는 공유 트랜잭션을 rollback-only로 표시하고(`globalRollbackOnParticipationFailure` 기본 true, spring-tx 소스로 확인), 그 표시는 catch로 지울 수 없어 `UnexpectedRollbackException`으로 끝납니다.

**수정.**

- **푸시를 `afterCommit`으로 이동** — 저장은 확정, 전달은 best-effort. `processCommit` 순서상 콜백 시점에 EntityManager가 열려 있음을 소스로 확인했고, 그럼에도 콜백을 DB-free로 유지하기 위해 트랜잭션 안에서 `Hibernate.initialize`로 선-초기화합니다. 동기화가 없는 호출(단위 테스트)은 인라인 푸시로 폴백
- **`generatePresignedGetUrlsLenient` 추가** — 서명 실패 미디어만 빼고 진행. 의도적으로 `@Transactional`이 없습니다: DB를 읽지 않는 메서드이고, afterCommit에서의 트랜잭션 프록시 진입은 "커밋이 뒤따르지 않는 참여"가 되는 Spring 금지 패턴입니다(`TransactionSynchronization#afterCommit` javadoc). `REQUIRES_NEW`는 피드 렌더 핫패스인 strict 오버로드 호출처들에 커넥션 2배 점유를 강제해 기각, `noRollbackFor`는 `SdkClientException`을 못 막아 기각
- **읽기 경로도 lenient 전환** — 위 표의 세 번째 문제 해소. WS와 무관하게 즉시 효력
- **`AsyncConfig` 예외 핸들러 복구** — 기존엔 `getMessage()`만 문자열 연결해 **저장소 전체의 모든 `@Async` 실패**(도메인 리스너 4종·이메일 포함)가 스택트레이스 없이 한 줄로 축약됐습니다. `Throwable`을 로거 마지막 인자로 전달. `NotificationEvent`에 `@ToString`(payload는 초대 토큰이 실리므로 제외)을 붙여 실패 로그에서 알림 재구성 가능

**프로덕션 영향**: WS off에서는 채널 부재 조기 반환으로 푸시 경로 자체를 타지 않아 동작 변화 없음. 읽기 경로 lenient와 `@Async` 로깅 복구만 즉시 효력이며 둘 다 개선 방향입니다. `openapi3.yaml` 무변경(API 표면 불변).

## PR Checklist

- [x] 코드가 정상적으로 빌드되었나요? (`./gradlew build` 성공, spec 무변경)
- [x] 적절한 테스트 코드가 추가되었나요? 추가되었다면 아래에 어떤 테스트인지 설명해 주세요.
  - [x] `NotificationPushResilienceIntegrationTests` (3건, 실제 빈·실제 트랜잭션) — S3 서명 실패에도 행 커밋 + URL 없이 푸시 + 같은 장애에서 읽기 경로 생존 / 채널 전송 실패에도 행 커밋 / 정상 경로 저장 후 푸시. **수정 전 코드에서는 앞의 두 테스트가 실패**합니다(예외가 INSERT를 롤백). `MediaDomainService`를 모킹하지 않고 `S3Template`에서 실패를 일으켜 관대한 서명 경로가 실제 코드로 실행됩니다
  - [x] `MediaDomainServiceTests` +2 — lenient가 실패분만 건너뛰고 계속 가는지, 비-UPLOADED도 예외 없이 스킵하는지
  - [x] `NotificationProcessorServiceTests` +2 — presign 예외가 전파되지 않고 저장이 유지되는 소실 회귀, 알림 비활성 사용자 스킵 경로
- [ ] 리뷰어 설정이 완료되었나요?

## Other

### 참고사항

멀티에이전트 분석(12) + 리뷰(15)를 거쳤고, 리뷰 발견 6건(테스트가 실제 트랜잭션 프록시를 우회하던 문제, lenient의 afterCommit 참여 잠복 위험, `@ToString` 토큰 노출, 테스트 결정성 2건, 미검증 경로 1건)을 모두 반영했습니다.

조사 중 발견된 **별건 결함 2가지** (이 PR 범위 밖, 별도 처리 권장):

1. `User.delete()`가 `profileImage`를 null로만 끊고 `markAsDeleted()`를 호출하지 않아 **탈퇴자 1명당 S3 객체 1개가 영구 잔존** — GC가 DELETED만 수거하므로 회수 불가. 개인정보 관점에서도 문제
2. `User.profileImage`의 `@OneToOne(fetch = LAZY)`가 무효 (nullable 소유측 + bytecode enhancement 미도입) — 모든 User 로드가 `media_files`를 조인

🤖 Generated with [Claude Code](https://claude.com/claude-code)