### PR TITLE
fix: 시리즈 편 수를 저장 카운터 대신 post_series_posts 행 수에서 파생

### DIFF
--- a/apps/server/src/main/java/com/skkil/sync/post/mapper/PostSeriesAssembler.java
+++ b/apps/server/src/main/java/com/skkil/sync/post/mapper/PostSeriesAssembler.java
@@ -6,10 +6,14 @@ import com.skkil.sync.post.dto.summary.PostSeriesSummary;
 import com.skkil.sync.post.dto.summary.PostSummary;
 import com.skkil.sync.post.model.PostSeries;
 import com.skkil.sync.post.model.PostSeriesPost;
+import com.skkil.sync.post.repository.PostSeriesPostRepository;
+import com.skkil.sync.post.repository.PostSeriesPostRepository.SeriesPostCount;
 import com.skkil.sync.post.service.PostDomainService;
 import com.skkil.sync.project.model.Project;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
@@ -17,24 +21,45 @@ import org.springframework.stereotype.Component;
 public class PostSeriesAssembler {
 
   private final PostDomainService postDomainService;
+  private final PostSeriesPostRepository seriesPostRepository;
 
-  public PostSeriesAssembler(PostDomainService postDomainService) {
+  public PostSeriesAssembler(
+      PostDomainService postDomainService, PostSeriesPostRepository seriesPostRepository) {
     this.postDomainService = postDomainService;
+    this.seriesPostRepository = seriesPostRepository;
   }
 
-  public PostSeriesSummary toSummary(PostSeries series) {
+  /**
+   * {@code postCount} 는 저장하지 않고 {@code post_series_posts} 행 수에서 파생한다. 게시글 삭제처럼 FK cascade 로 행이 사라지는
+   * 경로는 JPA 를 타지 않아 저장된 카운터가 조용히 어긋나기 때문이다. 호출자가 이미 행 수를 알고 있으면 그 값을 그대로 넘긴다.
+   */
+  public PostSeriesSummary toSummary(PostSeries series, long postCount) {
     Project project = series.getProject();
     return new PostSeriesSummary(
         series.getExternalId(),
         series.getName(),
         series.getScope(),
-        series.getPostCount(),
+        postCount,
         series.getCreator().getId(),
         project == null ? null : project.getHandle());
   }
 
   public GetPostSeriesListResponse toGetSeriesListResponse(List<PostSeries> seriesList) {
-    return new GetPostSeriesListResponse(seriesList.stream().map(this::toSummary).toList());
+    Map<Long, Long> counts = countsBySeriesId(seriesList);
+    return new GetPostSeriesListResponse(
+        seriesList.stream()
+            .map(series -> toSummary(series, counts.getOrDefault(series.getId(), 0L)))
+            .toList());
+  }
+
+  private Map<Long, Long> countsBySeriesId(List<PostSeries> seriesList) {
+    if (seriesList.isEmpty()) {
+      return Map.of();
+    }
+
+    List<Long> seriesIds = seriesList.stream().map(PostSeries::getId).toList();
+    return seriesPostRepository.countBySeriesIds(seriesIds).stream()
+        .collect(Collectors.toMap(SeriesPostCount::getSeriesId, SeriesPostCount::getPostCount));
   }
 
   public List<GetPostSeriesResponse.Post> toSeriesPostItems(
@@ -43,15 +68,19 @@ public class PostSeriesAssembler {
     Map<Long, PostSummary> visibleSummaries =
         postDomainService.getReadablePostSummaries(requesterId, postIds);
 
-    return items.stream().map(item -> toItem(item, visibleSummaries)).toList();
+    // 표시 순번은 저장된 position 이 아니라 정렬된 목록의 차례에서 파생한다. 우회 삭제 경로로
+    // 저장값에 구멍이 생겨도 사용자에게는 항상 1부터 연속된 번호로 보인다.
+    return IntStream.range(0, items.size())
+        .mapToObj(index -> toItem(items.get(index), index + 1, visibleSummaries))
+        .toList();
   }
 
   private GetPostSeriesResponse.Post toItem(
-      PostSeriesPost item, Map<Long, PostSummary> visibleSummaries) {
+      PostSeriesPost item, int position, Map<Long, PostSummary> visibleSummaries) {
     PostSummary summary = visibleSummaries.get(item.getPost().getId());
     // 열람할 수 없는 항목은 불투명 slot 이므로 제목뿐 아니라 이동 경로(slug)도 노출하지 않는다.
     String slug = summary == null ? null : summary.slug();
     String title = summary == null ? null : summary.title();
-    return new GetPostSeriesResponse.Post(item.getId(), item.getPosition(), slug, title);
+    return new GetPostSeriesResponse.Post(item.getId(), position, slug, title);
   }
 }

--- a/apps/server/src/main/java/com/skkil/sync/post/model/PostSeries.java
+++ b/apps/server/src/main/java/com/skkil/sync/post/model/PostSeries.java
@@ -13,6 +13,7 @@ import lombok.Builder;
 import lombok.Getter;
 import org.jspecify.annotations.Nullable;
 
+/** 편 수(postCount)는 저장하지 않는다 — {@code post_series_posts} 행 수에서 파생한다. */
 @Entity
 @Table(name = "post_series")
 @Getter
@@ -32,9 +33,6 @@ public class PostSeries extends BaseEntity {
   @Column(name = "name", nullable = false)
   private String name;
 
-  @Column(name = "post_count", nullable = false)
-  private long postCount = 0;
-
   protected PostSeries() {}
 
   @Builder
@@ -47,16 +45,6 @@ public class PostSeries extends BaseEntity {
 
   public void update(String name) {
     this.name = name;
-  }
-
-  public void incrementPostCount() {
-    this.postCount++;
-  }
-
-  public void decrementPostCount() {
-    if (this.postCount > 0) {
-      this.postCount--;
-    }
   }
 
   public PostScope getScope() {

--- a/apps/server/src/main/java/com/skkil/sync/post/repository/PostSeriesPostRepository.java
+++ b/apps/server/src/main/java/com/skkil/sync/post/repository/PostSeriesPostRepository.java
@@ -10,6 +10,13 @@ import org.springframework.data.repository.query.Param;
 
 public interface PostSeriesPostRepository extends JpaRepository<PostSeriesPost, Long> {
 
+  /** 시리즈별 실제 편 수 집계 프로젝션. 편 수는 저장된 카운터가 아니라 이 행 수에서 파생된다. */
+  interface SeriesPostCount {
+    Long getSeriesId();
+
+    long getPostCount();
+  }
+
   List<PostSeriesPost> findBySeriesIdOrderByPositionAscIdAsc(Long seriesId);
 
   boolean existsBySeriesIdAndPostId(Long seriesId, Long postId);
@@ -17,6 +24,11 @@ public interface PostSeriesPostRepository extends JpaRepository<PostSeriesPost, 
   boolean existsByPostId(Long postId);
 
   long countBySeriesId(Long seriesId);
+
+  @Query(
+      "SELECT sp.series.id AS seriesId, COUNT(sp) AS postCount FROM PostSeriesPost sp"
+          + " WHERE sp.series.id IN :seriesIds GROUP BY sp.series.id")
+  List<SeriesPostCount> countBySeriesIds(@Param("seriesIds") List<Long> seriesIds);
 
   Optional<PostSeriesPost> findByIdAndSeriesId(Long id, Long seriesId);
 

--- a/apps/server/src/main/java/com/skkil/sync/post/service/PostSeriesService.java
+++ b/apps/server/src/main/java/com/skkil/sync/post/service/PostSeriesService.java
@@ -151,7 +151,6 @@ public class PostSeriesService {
 
     seriesPostRepository.save(
         PostSeriesPost.builder().series(series).post(post).position(position).build());
-    series.incrementPostCount();
     post.markInSeries();
   }
 
@@ -189,7 +188,6 @@ public class PostSeriesService {
     int position = seriesPost.getPosition();
     seriesPostRepository.delete(seriesPost);
     seriesPostRepository.shiftDownAfter(series.getId(), position);
-    series.decrementPostCount();
     post.unmarkInSeries();
   }
 
@@ -232,7 +230,7 @@ public class PostSeriesService {
               List<PostSeriesPost> items =
                   seriesPostRepository.findBySeriesIdOrderByPositionAscIdAsc(series.getId());
               return new GetPostSeriesResponse(
-                  seriesAssembler.toSummary(series),
+                  seriesAssembler.toSummary(series, items.size()),
                   seriesPost.getId(),
                   seriesAssembler.toSeriesPostItems(items, requesterId));
             })

--- a/apps/server/src/main/java/com/skkil/sync/post/service/PostService.java
+++ b/apps/server/src/main/java/com/skkil/sync/post/service/PostService.java
@@ -19,6 +19,7 @@ import com.skkil.sync.post.model.Post;
 import com.skkil.sync.post.model.PostStatus;
 import com.skkil.sync.post.model.PostType;
 import com.skkil.sync.post.repository.PostRepository;
+import com.skkil.sync.post.repository.PostSeriesPostRepository;
 import com.skkil.sync.post.util.PostSlugGenerator;
 import com.skkil.sync.project.model.Project;
 import com.skkil.sync.project.service.ProjectDomainService;
@@ -46,6 +47,7 @@ public class PostService {
   private final ApplicationEventPublisher eventPublisher;
 
   private final PostRepository postRepository;
+  private final PostSeriesPostRepository seriesPostRepository;
 
   public PostService(
       UserDomainService userDomainService,
@@ -55,6 +57,7 @@ public class PostService {
       PostReferenceService postReferenceService,
       PostContentMediaService contentMediaService,
       PostRepository postRepository,
+      PostSeriesPostRepository seriesPostRepository,
       ApplicationEventPublisher eventPublisher) {
     this.userDomainService = userDomainService;
     this.projectDomainService = projectDomainService;
@@ -63,6 +66,7 @@ public class PostService {
     this.postReferenceService = postReferenceService;
     this.contentMediaService = contentMediaService;
     this.postRepository = postRepository;
+    this.seriesPostRepository = seriesPostRepository;
     this.eventPublisher = eventPublisher;
   }
 
@@ -365,6 +369,18 @@ public class PostService {
     if (!postRepository.existsById(postId)) {
       throw new PostNotFoundException(postId);
     }
+
+    // post_series_posts 는 FK cascade 로 함께 지워지지만 그 경로는 JPA 를 타지 않아 뒤쪽 편들의
+    // position 이 메워지지 않으므로, 게시글을 지우기 전에 편성을 먼저 정리한다.
+    seriesPostRepository
+        .findByPostId(postId)
+        .ifPresent(
+            seriesPost -> {
+              Long seriesId = seriesPost.getSeries().getId();
+              int position = seriesPost.getPosition();
+              seriesPostRepository.delete(seriesPost);
+              seriesPostRepository.shiftDownAfter(seriesId, position);
+            });
 
     postRepository.deleteById(postId);
   }

--- a/apps/server/src/main/resources/db/changelog/changesets/00008-drop-post-series-post-count.sql
+++ b/apps/server/src/main/resources/db/changelog/changesets/00008-drop-post-series-post-count.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+--changeset skkil:00008-drop-post-series-post-count
+
+-- post_series.post_count 는 추가 시에만 증가하고 게시글 삭제(FK cascade)로는 감소하지 않아
+-- 실제 편 수와 어긋난다. 편 수는 post_series_posts 행 수에서 파생하도록 바꾸고 컬럼을 제거한다.
+ALTER TABLE post_series DROP COLUMN post_count;

--- a/apps/server/src/main/resources/db/changelog/changesets/00009-renumber-post-series-positions.sql
+++ b/apps/server/src/main/resources/db/changelog/changesets/00009-renumber-post-series-positions.sql
@@ -1,0 +1,14 @@
+--liquibase formatted sql
+--changeset skkil:00009-renumber-post-series-positions
+
+-- 게시글 삭제가 FK cascade 로만 편성 행을 지우던 동안 생긴 position 구멍을 1부터 연속으로 메운다.
+-- 정렬 키는 조회 경로(findBySeriesIdOrderByPositionAscIdAsc)와 동일하게 (position, id) 를 쓴다.
+WITH renumbered AS (
+    SELECT id,
+           ROW_NUMBER() OVER (PARTITION BY post_series_id ORDER BY position, id) AS new_position
+    FROM post_series_posts
+)
+UPDATE post_series_posts sp
+SET position = r.new_position
+FROM renumbered r
+WHERE sp.id = r.id AND sp.position <> r.new_position;

--- a/apps/server/src/test/java/com/skkil/sync/post/service/PostSeriesDerivedCountIntegrationTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/post/service/PostSeriesDerivedCountIntegrationTests.java
@@ -1,0 +1,207 @@
+package com.skkil.sync.post.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.skkil.sync.auth.AuthenticatedUser;
+import com.skkil.sync.common.config.TestcontainersConfig;
+import com.skkil.sync.post.dto.request.AddPostToPostSeriesRequest;
+import com.skkil.sync.post.dto.response.GetPostSeriesListResponse;
+import com.skkil.sync.post.dto.response.GetPostSeriesResponse;
+import com.skkil.sync.post.model.Post;
+import com.skkil.sync.post.model.PostSeries;
+import com.skkil.sync.post.model.PostSeriesPost;
+import com.skkil.sync.post.model.PostStatus;
+import com.skkil.sync.post.model.PostType;
+import com.skkil.sync.post.repository.PostRepository;
+import com.skkil.sync.post.repository.PostSeriesPostRepository;
+import com.skkil.sync.post.repository.PostSeriesRepository;
+import com.skkil.sync.user.constant.Role;
+import com.skkil.sync.user.model.User;
+import com.skkil.sync.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 시리즈 편 수와 순번이 post_series_posts 행에서 파생되는지 검증한다. 과거에는 post_series 에 저장된 카운터를 썼는데, 게시글 삭제가 FK
+ * cascade 로만 편성 행을 지워 카운터가 감소하지 않고 부풀어 남는 버그가 있었다(추가 누적 6 vs 실제 3). 파생 방식에서는 어떤 삭제 경로든 행이 사라지는 즉시
+ * 값이 맞는다.
+ */
+@Import(TestcontainersConfig.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = "app.seed.enabled=false")
+@Transactional
+class PostSeriesDerivedCountIntegrationTests {
+
+  @Autowired private PostSeriesService seriesService;
+  @Autowired private PostService postService;
+
+  @Autowired private UserRepository userRepository;
+  @Autowired private PostRepository postRepository;
+  @Autowired private PostSeriesRepository seriesRepository;
+  @Autowired private PostSeriesPostRepository seriesPostRepository;
+
+  @Autowired private EntityManager entityManager;
+
+  private User user;
+  private PostSeries series;
+  private List<Post> posts;
+  private long unique;
+
+  @BeforeEach
+  void setUp() {
+    unique = System.nanoTime();
+    user =
+        userRepository.save(
+            User.builder()
+                .email("series-tester-" + unique + "@example.com")
+                .fullName("Series Tester")
+                .build());
+    authenticate(user);
+
+    series =
+        seriesRepository.save(
+            PostSeries.builder().externalId("series-" + unique).creator(user).name("ps").build());
+
+    posts = new ArrayList<>();
+    for (int i = 1; i <= 3; i++) {
+      posts.add(saveAndAttachPost("series-post-" + unique + "-" + i, PostStatus.PUBLISHED));
+    }
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  @DisplayName("[getMyPersonalSeries] postCount 는 실제 편 수에서 파생된다")
+  void postCountIsDerivedFromRows() {
+    assertThat(myPersonalSeriesPostCount()).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("[deletePost] 전부 지우고 다시 채워도 편 수가 누적되지 않는다")
+  void postCountDoesNotAccumulateAcrossDeletes() {
+    for (Post post : posts) {
+      postService.deletePost(post.getId());
+    }
+    assertThat(myPersonalSeriesPostCount()).isZero();
+
+    for (int i = 1; i <= 3; i++) {
+      saveAndAttachPost("series-post-again-" + unique + "-" + i, PostStatus.PUBLISHED);
+    }
+    entityManager.flush();
+    entityManager.clear();
+
+    // 저장 카운터였다면 6 으로 부풀었을 값이다.
+    assertThat(myPersonalSeriesPostCount()).isEqualTo(3);
+    assertThat(seriesPostRepository.findBySeriesIdOrderByPositionAscIdAsc(series.getId()))
+        .extracting(PostSeriesPost::getPosition)
+        .containsExactly(1, 2, 3);
+  }
+
+  @Test
+  @DisplayName("[deletePost] 가운데 편을 지우면 편 수와 순번이 함께 정리된다")
+  void deletePostRemovesMembershipAndClosesPositionGap() {
+    postService.deletePost(posts.get(1).getId());
+    entityManager.flush();
+    entityManager.clear();
+
+    assertThat(myPersonalSeriesPostCount()).isEqualTo(2);
+
+    List<PostSeriesPost> remaining =
+        seriesPostRepository.findBySeriesIdOrderByPositionAscIdAsc(series.getId());
+    assertThat(remaining).extracting(PostSeriesPost::getPosition).containsExactly(1, 2);
+    assertThat(remaining)
+        .extracting(item -> item.getPost().getId())
+        .containsExactly(posts.get(0).getId(), posts.get(2).getId());
+
+    GetPostSeriesResponse forPost = seriesService.getSeriesForPost(posts.get(0).getSlug(), null);
+    assertThat(forPost.series()).isNotNull();
+    assertThat(forPost.series().postCount()).isEqualTo(2);
+    assertThat(forPost.posts())
+        .extracting(GetPostSeriesResponse.Post::position)
+        .containsExactly(1, 2);
+  }
+
+  @Test
+  @DisplayName("[deletePost] 시리즈에 편성된 초안을 지워도 편 수가 정리된다")
+  void deletingDraftInSeriesCleansUpCount() {
+    Post draft = saveAndAttachPost("series-draft-" + unique, PostStatus.DRAFT);
+    assertThat(myPersonalSeriesPostCount()).isEqualTo(4);
+
+    postService.deletePost(draft.getId());
+    entityManager.flush();
+    entityManager.clear();
+
+    assertThat(myPersonalSeriesPostCount()).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("[removeItem] 기존 편성 해제 경로도 편 수와 순번을 동일하게 정리한다")
+  void removeItemStaysConsistentWithDerivedCount() {
+    PostSeriesPost seriesPost =
+        seriesPostRepository.findByPostId(posts.get(0).getId()).orElseThrow();
+
+    seriesService.removeItem(series.getExternalId(), seriesPost.getId());
+    entityManager.flush();
+    entityManager.clear();
+
+    assertThat(myPersonalSeriesPostCount()).isEqualTo(2);
+    assertThat(seriesPostRepository.findBySeriesIdOrderByPositionAscIdAsc(series.getId()))
+        .extracting(PostSeriesPost::getPosition)
+        .containsExactly(1, 2);
+  }
+
+  private long myPersonalSeriesPostCount() {
+    GetPostSeriesListResponse response = seriesService.getMyPersonalSeries(user.getId());
+    assertThat(response.series()).hasSize(1);
+    return response.series().get(0).postCount();
+  }
+
+  private Post saveAndAttachPost(String slug, PostStatus status) {
+    Post post =
+        Post.builder()
+            .slug(slug)
+            .author(user)
+            .title("시리즈 편 " + slug)
+            .type(PostType.LONG)
+            .status(status)
+            .jsonContent("본문")
+            .build();
+    post.updateJsonContent("본문", "본문", 0);
+    post = postRepository.saveAndFlush(post);
+
+    seriesService.addPost(
+        user.getId(),
+        series.getExternalId(),
+        new AddPostToPostSeriesRequest(null, post.getSlug(), null));
+    return post;
+  }
+
+  private void authenticate(User user) {
+    AuthenticatedUser principal =
+        new AuthenticatedUser(
+            user.getId(), user.getFullName(), user.getEmail(), null, Role.USER, true);
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            UsernamePasswordAuthenticationToken.authenticated(
+                principal, null, principal.getAuthorities()));
+  }
+}

--- a/apps/web/src/components/feature/post/hooks/postQueryKeys.ts
+++ b/apps/web/src/components/feature/post/hooks/postQueryKeys.ts
@@ -26,6 +26,9 @@ export function isPostRelatedQueryKey(queryKey: readonly unknown[]) {
     path === '/search/posts' ||
     /^\/users\/[^/]+\/posts$/.test(path) ||
     /^\/projects\/[^/]+\/posts(\/pinned)?$/.test(path) ||
+    // 시리즈 목록의 postCount 는 실제 편 수에서 파생되므로 게시글 변경에 함께 무효화한다.
+    path === '/me/series' ||
+    /^\/projects\/[^/]+\/series$/.test(path) ||
     /^\/profiles\/[^/]+\/posts\/activities$/.test(path) ||
     /^\/tags\/[^/]+\/posts$/.test(path) ||
     /^\/collections\/[^/]+\/posts$/.test(path)

--- a/apps/web/src/components/feature/post/viewer/PostSeriesCard.tsx
+++ b/apps/web/src/components/feature/post/viewer/PostSeriesCard.tsx
@@ -38,7 +38,7 @@ export function PostSeriesCard({ slug }: PostSeriesCardProps) {
   }
 
   const items = seriesData?.data.posts ?? [];
-  // 순서는 목록에서 직접 찾는다. denormalize 된 postCount 대신 실제 항목 수를 쓴다.
+  // 순서는 목록에서 직접 찾는다. 서버 postCount 도 행 수에서 파생된 값이지만, 이미 받은 목록이 있으므로 항목 수를 그대로 쓴다.
   const position =
     items.find((item) => item.seriesPostId === currentSeriesPostId)?.position ??
     0;


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 버그 수정
- Related Issue: 없음

`post_series.post_count` 가 실제 편 수와 어긋나는 문제를 고칩니다. 이 컬럼은 편성 추가 시에만 증가하고, 게시글 삭제로 편성 행이 사라질 때는 감소하지 않았습니다 — 삭제 경로가 DB FK cascade 로만 처리되어 JPA 를 타지 않기 때문입니다. **게시된 3편이 에디터에 6편으로 표시되는 형태**로 드러났습니다.

저장 카운터를 없애고 `post_series_posts` 행 수에서 파생하도록 바꿉니다.

- **카운터 컬럼 제거** — 목록·뷰어 응답 모두 행 수를 집계해 파생 (`PostSeriesAssembler`, `PostSeries`, `PostSeriesPostRepository`)
- **삭제 시 편성을 직접 정리** — `PostService.deletePost` 가 cascade 에 맡기기 전에 편성 행을 지우고 뒤쪽 편 순번을 당깁니다. cascade 는 JPA 를 거치지 않아 `position` 구멍이 남았습니다
- **표시 순번도 파생** — 정렬된 목록에서의 차례로 계산해, 저장된 `position` 에 구멍이 있어도 UI 에 드러나지 않습니다
- **마이그레이션 2건**
  - `00008` — `post_series.post_count` 컬럼 제거
  - `00009` — 그동안 생긴 `position` 구멍을 1부터 연속으로 일괄 보정. 정렬 키 `(position, id)` 는 조회 경로(`findBySeriesIdOrderByPositionAscIdAsc`)와 동일하게 맞췄습니다
- **웹** — 게시글 변경 시 시리즈 목록 캐시(`/me/series`, `/projects/*/series`)도 무효화 (`postQueryKeys`), `PostSeriesCard` 표시 보정

## PR Checklist

- [x] 코드가 정상적으로 빌드되었나요? (`./gradlew build` 성공 — 마이그레이션 2건 포함, 웹 `format`/`lint`/`tsc --noEmit`/`build` 통과, 생성 파일 드리프트 없음)
- [x] 적절한 테스트 코드가 추가되었나요? 추가되었다면 아래에 어떤 테스트인지 설명해 주세요.
  - [x] `PostSeriesDerivedCountIntegrationTests` 5건 — 핵심은 **전부 삭제 후 재편성 시 편 수가 누적되지 않는지**(원래 버그의 직접 회귀). 함께 파생 편 수 정확성, 삭제 후 뒤쪽 순번 당김, 표시 순번 파생을 검증합니다
  - [x] 기존 `PostSeriesControllerTests` 10건도 통과 (총 15건)
- [ ] 리뷰어 설정이 완료되었나요?

## Other

### 참고사항

**리뷰 시 확인 부탁드릴 지점:**

1. `00009` 마이그레이션은 되돌릴 수 없는 데이터 보정입니다(구멍 난 `position` 을 연속 번호로 덮어씀). 정렬 키를 조회 경로와 일치시켜 순서는 보존하지만, 배포 전 프로덕션 데이터에서 영향 행 수를 한 번 확인해 두면 좋습니다.
2. 편 수를 매 조회 시 집계하므로 시리즈당 `COUNT` 가 늘어납니다. 현재 시리즈 규모에서는 문제되지 않는다고 판단했지만, 시리즈가 커지면 배치 집계로 바꿀 여지가 있습니다.
3. `deletePost` 가 편성 정리를 먼저 하도록 바뀌어 cascade 와 역할이 겹칩니다 — cascade 는 안전망으로 남겨뒀습니다.

