### PR TITLE
fix: 세션 무효화 시 살아 있는 WebSocket 소켓도 함께 종료

### DIFF
--- a/apps/server/src/main/java/com/skkil/sync/auth/session/PrincipalTrackingHandshakeDecorator.java
+++ b/apps/server/src/main/java/com/skkil/sync/auth/session/PrincipalTrackingHandshakeDecorator.java
@@ -1,0 +1,45 @@
+package com.skkil.sync.auth.session;
+
+import java.security.Principal;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.WebSocketHandlerDecorator;
+
+/**
+ * 전송 계층에서 연결 수립·종료를 가로채 {@link WebSocketSessionRegistry}를 채운다.
+ *
+ * <p>STOMP 프레임이 아니라 소켓 자체에 걸리므로 CONNECT 프레임·CSRF 검증보다 먼저 동작하고, 구독 여부와 무관하게 모든 인증된 연결을 추적한다. 핸드셰이크는
+ * HTTP 필터 체인의 {@code anyRequest().authenticated()}를 통과했으므로 Principal이 존재하며, 그 이름은 이메일이다.
+ */
+public class PrincipalTrackingHandshakeDecorator extends WebSocketHandlerDecorator {
+
+  private final WebSocketSessionRegistry registry;
+
+  public PrincipalTrackingHandshakeDecorator(
+      WebSocketHandler delegate, WebSocketSessionRegistry registry) {
+    super(delegate);
+    this.registry = registry;
+  }
+
+  @Override
+  public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+    Principal principal = session.getPrincipal();
+    if (principal != null) {
+      registry.register(principal.getName(), session);
+    }
+
+    super.afterConnectionEstablished(session);
+  }
+
+  @Override
+  public void afterConnectionClosed(WebSocketSession session, CloseStatus closeStatus)
+      throws Exception {
+    Principal principal = session.getPrincipal();
+    if (principal != null) {
+      registry.unregister(principal.getName(), session.getId());
+    }
+
+    super.afterConnectionClosed(session, closeStatus);
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/auth/session/SessionInvalidationService.java
+++ b/apps/server/src/main/java/com/skkil/sync/auth/session/SessionInvalidationService.java
@@ -3,6 +3,7 @@ package com.skkil.sync.auth.session;
 import com.skkil.sync.auth.agent.AgentAuthorizationRevoker;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.session.Session;
 import org.springframework.stereotype.Service;
@@ -10,8 +11,9 @@ import org.springframework.stereotype.Service;
 /**
  * 비밀번호가 바뀌었을 때 그 계정으로 발급된 자격 증명을 전부 끊는다.
  *
- * <p>세션만으로는 부족하다. 에이전트 OAuth2 인가는 세션 저장소가 아니라 {@code oauth2_authorization} 에 남고, 갱신 토큰은 60일을 산다. 둘을
- * 한자리에서 지워야 "비밀번호를 바꾸면 모든 자격 증명이 무효가 된다"는 규칙이 실제로 성립한다.
+ * <p>세션만으로는 부족하다. 에이전트 OAuth2 인가는 세션 저장소가 아니라 {@code oauth2_authorization} 에 남고, 갱신 토큰은 60일을 산다.
+ * WebSocket 연결은 핸드셰이크 시점의 Principal을 끝까지 유지해 세션 행 삭제로는 끊기지 않는다. 셋을 한자리에서 지워야 "비밀번호를 바꾸면 모든 자격 증명이
+ * 무효가 된다"는 규칙이 실제로 성립한다.
  */
 @Service
 @Slf4j
@@ -19,12 +21,15 @@ public class SessionInvalidationService {
 
   private final FindByIndexNameSessionRepository<? extends Session> sessionRepository;
   private final AgentAuthorizationRevoker agentAuthorizationRevoker;
+  private final ObjectProvider<WebSocketSessionRegistry> webSocketSessionRegistry;
 
   public SessionInvalidationService(
       FindByIndexNameSessionRepository<? extends Session> sessionRepository,
-      AgentAuthorizationRevoker agentAuthorizationRevoker) {
+      AgentAuthorizationRevoker agentAuthorizationRevoker,
+      ObjectProvider<WebSocketSessionRegistry> webSocketSessionRegistry) {
     this.sessionRepository = sessionRepository;
     this.agentAuthorizationRevoker = agentAuthorizationRevoker;
+    this.webSocketSessionRegistry = webSocketSessionRegistry;
   }
 
   public void invalidateAllSessions(String principalName) {
@@ -34,5 +39,21 @@ public class SessionInvalidationService {
     log.info("Invalidated {} session(s)", sessions.size());
 
     agentAuthorizationRevoker.revokeAll(principalName);
+    closeWebSocketSessions(principalName);
+  }
+
+  /**
+   * 소켓 종료는 즉시 수행한다 — 알림 푸시처럼 커밋 뒤로 미루지 않는다. 실패 방향이 반대이기 때문이다: 트랜잭션이 롤백됐는데 소켓을 끊었다면 클라이언트가 재연결하면
+   * 그만이지만, 커밋 후 콜백이 실행되지 않아 소켓이 살아남으면 무효화된 자격 증명이 계속 알림을 받는다. 보안에서는 과하게 끊는 쪽이 안전하다.
+   *
+   * <p>반대로 종료 실패가 비밀번호 변경·계정 삭제를 되돌려서도 안 되므로 예외는 흡수한다. 레지스트리 빈은 WebSocket이 켜진 구성에만 존재한다 ({@code
+   * app.websocket.enabled}).
+   */
+  private void closeWebSocketSessions(String principalName) {
+    try {
+      webSocketSessionRegistry.ifAvailable(registry -> registry.closeAll(principalName));
+    } catch (RuntimeException exception) {
+      log.warn("WebSocket 세션 종료에 실패했다. principal={}", principalName, exception);
+    }
   }
 }

--- a/apps/server/src/main/java/com/skkil/sync/auth/session/WebSocketSessionRegistry.java
+++ b/apps/server/src/main/java/com/skkil/sync/auth/session/WebSocketSessionRegistry.java
@@ -1,0 +1,81 @@
+package com.skkil.sync.auth.session;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+
+/**
+ * principal 이름별로 살아 있는 WebSocket 세션을 추적한다.
+ *
+ * <p>STOMP 세션의 Principal은 핸드셰이크 시점에 고정되고 이후 재검증되지 않으므로, 세션 저장소의 행을 지우는 것({@link
+ * SessionInvalidationService})만으로는 이미 열린 소켓이 끊기지 않는다. 프레임워크가 이 연결 고리를 제공하지 않는다 — {@code
+ * SimpUserRegistry}는 {@code WebSocketSession} 참조를 들고 있지 않고, spring-session의 {@code
+ * WebSocketRegistryListener}는 JDBC 세션 저장소가 발행하지 않는 {@code SessionDestroyedEvent}를 기다린다. 그래서 전송 계층
+ * 데코레이터({@link PrincipalTrackingHandshakeDecorator})가 직접 채운다.
+ *
+ * <p>키는 principal 이름(= 이메일, {@code AuthenticatedUser.getName()})이다. 세션 무효화가 principal 단위로 동작하므로 같은
+ * 키를 쓴다 — HTTP 세션 ID로 잡으면 "비밀번호 변경 = 모든 기기 로그아웃" 보장이 기기 하나로 좁아진다.
+ *
+ * <p>인메모리이므로 다중 인스턴스에서는 자기 인스턴스의 소켓만 끊는다. 현재 배포는 단일 인스턴스이고, 스케일아웃은 인메모리 STOMP 브로커와 같은 지점에서 함께 깨지므로
+ * 외부 브로커 도입 시 이 레지스트리도 같이 다뤄야 한다.
+ */
+@Component
+@ConditionalOnProperty(name = "app.websocket.enabled", havingValue = "true", matchIfMissing = false)
+@Slf4j
+public class WebSocketSessionRegistry {
+
+  /** 로그아웃·타임아웃이 아니라 자격 증명 무효화로 서버가 끊었음을 클라이언트에 알린다. */
+  private static final CloseStatus CREDENTIALS_INVALIDATED =
+      new CloseStatus(
+          CloseStatus.POLICY_VIOLATION.getCode(), "Credentials for this session were invalidated");
+
+  private final Map<String, Map<String, WebSocketSession>> sessionsByPrincipal =
+      new ConcurrentHashMap<>();
+
+  void register(String principalName, WebSocketSession session) {
+    sessionsByPrincipal
+        .computeIfAbsent(principalName, key -> new ConcurrentHashMap<>())
+        .put(session.getId(), session);
+  }
+
+  void unregister(String principalName, String webSocketSessionId) {
+    Map<String, WebSocketSession> sessions = sessionsByPrincipal.get(principalName);
+    if (sessions == null) {
+      return;
+    }
+
+    sessions.remove(webSocketSessionId);
+    if (sessions.isEmpty()) {
+      // 같은 맵일 때만 제거해, 방금 새 세션을 등록한 동시 연결을 지우지 않는다.
+      sessionsByPrincipal.remove(principalName, sessions);
+    }
+  }
+
+  /** 해당 principal의 소켓을 전부 닫는다. 개별 종료 실패는 나머지 종료를 막지 않는다. */
+  public void closeAll(String principalName) {
+    Map<String, WebSocketSession> sessions = sessionsByPrincipal.remove(principalName);
+    if (sessions == null) {
+      return;
+    }
+
+    log.info("Closing {} WebSocket session(s) for invalidated principal", sessions.size());
+    for (WebSocketSession session : sessions.values()) {
+      try {
+        session.close(CREDENTIALS_INVALIDATED);
+      } catch (IOException exception) {
+        // 이미 끊긴 소켓일 가능성이 높다. 서버측 자원은 컨테이너가 정리한다.
+        log.debug("WebSocket 세션 {} 종료 실패", session.getId(), exception);
+      }
+    }
+  }
+
+  /** 테스트 전용 — 레지스트리 누수 검증용. */
+  boolean hasSessions(String principalName) {
+    return sessionsByPrincipal.containsKey(principalName);
+  }
+}

--- a/apps/server/src/main/java/com/skkil/sync/config/WebSocketConfig.java
+++ b/apps/server/src/main/java/com/skkil/sync/config/WebSocketConfig.java
@@ -1,5 +1,7 @@
 package com.skkil.sync.config;
 
+import com.skkil.sync.auth.session.PrincipalTrackingHandshakeDecorator;
+import com.skkil.sync.auth.session.WebSocketSessionRegistry;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
@@ -7,6 +9,7 @@ import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
 
 @Configuration
 @ConditionalOnProperty(name = "app.websocket.enabled", havingValue = "true", matchIfMissing = false)
@@ -15,6 +18,12 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   @Value("${app.cors.allowed-origins}")
   private String[] allowedOrigins;
+
+  private final WebSocketSessionRegistry sessionRegistry;
+
+  public WebSocketConfig(WebSocketSessionRegistry sessionRegistry) {
+    this.sessionRegistry = sessionRegistry;
+  }
 
   @Override
   public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -29,5 +38,13 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
     registry.addEndpoint("/ws").setAllowedOrigins(allowedOrigins).withSockJS();
+  }
+
+  @Override
+  public void configureWebSocketTransport(WebSocketTransportRegistration registration) {
+    // 세션 무효화(비밀번호 변경·계정 삭제)가 살아 있는 소켓까지 끊을 수 있도록,
+    // 모든 연결을 principal 이름으로 레지스트리에 등록한다.
+    registration.addDecoratorFactory(
+        handler -> new PrincipalTrackingHandshakeDecorator(handler, sessionRegistry));
   }
 }

--- a/apps/server/src/test/java/com/skkil/sync/auth/session/PasswordSessionInvalidationIntegrationTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/auth/session/PasswordSessionInvalidationIntegrationTests.java
@@ -31,6 +31,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import tools.jackson.databind.json.JsonMapper;
 
+/**
+ * 비밀번호 변경·재설정이 HTTP 세션을 전부 무효화하는지(이후 요청 401) 검증한다.
+ *
+ * <p>살아 있는 WebSocket 소켓의 종료는 이 테스트의 범위 밖이다 — {@link WebSocketSessionTerminationIntegrationTests}가
+ * 담당한다. 두 테스트가 함께 있어야 "비밀번호를 바꾸면 모든 자격 증명이 무효가 된다" 규칙이 채널 전체에서 검증된다.
+ */
 @Import(TestcontainersConfig.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/apps/server/src/test/java/com/skkil/sync/auth/session/WebSocketSessionTerminationIntegrationTests.java
+++ b/apps/server/src/test/java/com/skkil/sync/auth/session/WebSocketSessionTerminationIntegrationTests.java
@@ -1,0 +1,219 @@
+package com.skkil.sync.auth.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.skkil.sync.common.config.TestcontainersConfig;
+import com.skkil.sync.user.dto.request.ChangePasswordRequest;
+import com.skkil.sync.user.model.User;
+import com.skkil.sync.user.repository.UserRepository;
+import com.skkil.sync.user.service.AuthService;
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+/**
+ * 세션 무효화가 살아 있는 WebSocket 소켓까지 끊는지 실제 포트 위에서 검증한다.
+ *
+ * <p>STOMP Principal은 핸드셰이크 시점에 고정되므로 세션 저장소 행 삭제만으로는 소켓이 살아남는다 — HTTP 경로의 401 전환은 {@link
+ * PasswordSessionInvalidationIntegrationTests}가, 소켓 종료는 이 테스트가 담당한다. 레지스트리가 STOMP 프레임이 아니라 전송
+ * 계층({@code afterConnectionEstablished})에 걸리므로, SockJS raw websocket 경로로 붙기만 하면 CONNECT 프레임 없이도
+ * 추적·종료를 검증할 수 있다.
+ */
+@Import(TestcontainersConfig.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {"app.seed.enabled=false", "app.websocket.enabled=true"})
+class WebSocketSessionTerminationIntegrationTests {
+
+  private static final String PASSWORD = "password1234";
+
+  /** server.servlet.session.cookie.name — 실 HTTP에서는 소문자다(MockMvc는 서블릿 설정을 타지 않는다). */
+  private static final String SESSION_COOKIE = "session";
+
+  private static final int CREDENTIALS_INVALIDATED_CODE = CloseStatus.POLICY_VIOLATION.getCode();
+
+  @LocalServerPort private int port;
+
+  @Autowired private UserRepository userRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
+  @Autowired private SessionInvalidationService sessionInvalidationService;
+  @Autowired private WebSocketSessionRegistry registry;
+  @Autowired private AuthService authService;
+
+  private final List<WebSocketSession> openedSessions = new java.util.ArrayList<>();
+
+  private User user;
+  private User otherUser;
+
+  @BeforeEach
+  void setUp() {
+    user = saveUser();
+    otherUser = saveUser();
+  }
+
+  @AfterEach
+  void tearDown() {
+    for (WebSocketSession session : openedSessions) {
+      try {
+        session.close();
+      } catch (Exception ignored) {
+        // 이미 닫힌 소켓 정리 시도는 무시한다.
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("세션 무효화는 해당 principal의 소켓만 끊는다")
+  void invalidateAllSessions_closesOnlyTargetPrincipalSockets() throws Exception {
+    ConnectedClient target = connectAs(user.getEmail());
+    ConnectedClient bystander = connectAs(otherUser.getEmail());
+
+    sessionInvalidationService.invalidateAllSessions(user.getEmail());
+
+    assertThat(target.handler.closed.await(10, TimeUnit.SECONDS))
+        .as("무효화된 principal의 소켓은 닫혀야 한다")
+        .isTrue();
+    assertThat(target.handler.closeStatus.getCode()).isEqualTo(CREDENTIALS_INVALIDATED_CODE);
+    assertThat(registry.hasSessions(user.getEmail())).isFalse();
+
+    // 다른 사용자는 영향받지 않는다 — 키 격리 회귀.
+    assertThat(bystander.session.isOpen()).isTrue();
+    assertThat(registry.hasSessions(otherUser.getEmail())).isTrue();
+  }
+
+  @Test
+  @DisplayName("비밀번호를 변경하면 열려 있던 소켓이 끊긴다")
+  void changePassword_closesLiveSockets() throws Exception {
+    ConnectedClient client = connectAs(user.getEmail());
+
+    authService.changePassword(
+        user.getId(), new ChangePasswordRequest(PASSWORD, "newPassword1234"));
+
+    assertThat(client.handler.closed.await(10, TimeUnit.SECONDS))
+        .as("비밀번호 변경 후 기존 소켓은 닫혀야 한다")
+        .isTrue();
+    assertThat(client.handler.closeStatus.getCode()).isEqualTo(CREDENTIALS_INVALIDATED_CODE);
+  }
+
+  @Test
+  @DisplayName("정상 종료된 소켓은 레지스트리에서 제거되고, 이후 무효화는 no-op이다")
+  void normalClose_unregistersFromRegistry() throws Exception {
+    ConnectedClient client = connectAs(user.getEmail());
+    assertThat(registry.hasSessions(user.getEmail())).isTrue();
+
+    client.session.close();
+
+    awaitUnregistered(user.getEmail());
+    sessionInvalidationService.invalidateAllSessions(user.getEmail());
+  }
+
+  private void awaitUnregistered(String email) throws InterruptedException {
+    long deadline = System.currentTimeMillis() + 10_000;
+    while (System.currentTimeMillis() < deadline) {
+      if (!registry.hasSessions(email)) {
+        return;
+      }
+      Thread.sleep(50);
+    }
+    throw new AssertionError("소켓 정상 종료 후에도 레지스트리에 세션이 남아 있다");
+  }
+
+  private ConnectedClient connectAs(String email) throws Exception {
+    String sessionCookie = login(email);
+
+    WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
+    headers.add(HttpHeaders.COOKIE, SESSION_COOKIE + "=" + sessionCookie);
+
+    // SockJS raw websocket 전송 경로 — /ws/info 왕복과 STOMP 프레임 없이 소켓만 세운다.
+    URI uri =
+        URI.create(
+            "ws://localhost:"
+                + port
+                + "/ws/0/"
+                + UUID.randomUUID().toString().replace("-", "")
+                + "/websocket");
+
+    TrackingSocketHandler handler = new TrackingSocketHandler();
+    WebSocketSession session =
+        new StandardWebSocketClient().execute(handler, headers, uri).get(10, TimeUnit.SECONDS);
+    openedSessions.add(session);
+
+    return new ConnectedClient(session, handler);
+  }
+
+  /** CSRF 프라이밍 → 로그인으로 실제 SESSION 쿠키를 얻는다 (MockMvc가 아닌 실 HTTP). */
+  private String login(String email) {
+    RestClient client = RestClient.create("http://localhost:" + port);
+
+    ResponseEntity<Void> csrfResponse =
+        client.get().uri("/auth/csrf").retrieve().toBodilessEntity();
+    String csrfToken = cookieValue(csrfResponse, "XSRF-TOKEN");
+
+    ResponseEntity<Void> loginResponse =
+        client
+            .post()
+            .uri("/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.COOKIE, "XSRF-TOKEN=" + csrfToken)
+            .header("X-XSRF-TOKEN", csrfToken)
+            .body("{\"email\":\"" + email + "\",\"password\":\"" + PASSWORD + "\"}")
+            .retrieve()
+            .toBodilessEntity();
+
+    return cookieValue(loginResponse, SESSION_COOKIE);
+  }
+
+  private static String cookieValue(ResponseEntity<?> response, String cookieName) {
+    List<String> cookies = response.getHeaders().getOrEmpty(HttpHeaders.SET_COOKIE);
+    return cookies.stream()
+        .filter(cookie -> cookie.startsWith(cookieName + "="))
+        .map(cookie -> cookie.substring(cookieName.length() + 1, cookie.indexOf(';')))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError(cookieName + " 쿠키가 응답에 없다: " + cookies));
+  }
+
+  private User saveUser() {
+    return userRepository.save(
+        User.builder()
+            .email("ws-termination-" + System.nanoTime() + "@example.com")
+            .fullName("소켓 종료 테스트")
+            .hashedPassword(passwordEncoder.encode(PASSWORD))
+            .build());
+  }
+
+  private record ConnectedClient(WebSocketSession session, TrackingSocketHandler handler) {}
+
+  private static final class TrackingSocketHandler extends TextWebSocketHandler {
+
+    private final CountDownLatch closed = new CountDownLatch(1);
+    private volatile CloseStatus closeStatus = CloseStatus.NO_STATUS_CODE;
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+      this.closeStatus = status;
+      this.closed.countDown();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

### 어떤 변경 사항이 있나요?

- Category: 버그 수정 (보안)
- Related Issue: 없음

WebSocket 활성화 선행 조건 시리즈(#220 → #221 → #222)의 마지막 서버 조각입니다. 이 PR이 머지되면 남는 것은 인프라 변경(nginx Upgrade 헤더, 플래그 전환)뿐입니다.

**문제.** STOMP 세션의 Principal은 핸드셰이크 시점에 한 번 고정되고 이후 재검증되지 않습니다. 그래서 비밀번호 변경·재설정·계정 삭제가 `SessionInvalidationService`로 JDBC 세션 행을 전부 지워도, **이미 열린 소켓은 알림을 계속 수신**합니다. 세션을 탈취당한 사용자가 비밀번호를 바꿔도 공격자의 열린 연결이 안 끊기는 구멍입니다 — HTTP 요청은 즉시 401이 되는데 WS만 살아남는 비대칭입니다. 특히 비밀번호 재설정은 계정 탈취 복구의 정의상 경로라 가장 민감합니다.

**프레임워크가 연결 고리를 제공하지 않습니다.** `SimpUserRegistry`는 `WebSocketSession` 참조를 들고 있지 않고, `SubProtocolWebSocketHandler`의 세션 맵은 접근 불가이며, spring-session의 `WebSocketRegistryListener`는 JDBC 세션 저장소가 발행하지 않는 `SessionDestroyedEvent`를 기다립니다(소스로 확인 — `JdbcIndexedSessionRepository.deleteById`는 순수 SQL DELETE). 남는 경로는 전송 계층 데코레이터뿐입니다.

**수정.**

- **`WebSocketSessionRegistry`** — principal 이름(이메일, `AuthenticatedUser.getName()`과 동일 계약)별로 살아 있는 소켓을 추적. `WebSocketTransportRegistration.addDecoratorFactory`로 등록되는 `PrincipalTrackingHandshakeDecorator`가 연결 수립/종료 시 채우고 비웁니다
- **`SessionInvalidationService` 훅** — 세션 삭제·에이전트 토큰 회수에 이어 해당 principal의 소켓을 전부 닫습니다(1008 `POLICY_VIOLATION`, 사유 명시). 종료 실패는 흡수해 비밀번호 변경 트랜잭션을 절대 깨뜨리지 않습니다
- **키 선택** — spring-session 참고 구현은 HTTP 세션 ID로 키를 잡지만, 우리 무효화는 principal 단위("비밀번호 변경 = 모든 기기 로그아웃")이므로 principal 키가 맞습니다

**설계 노트 — #222와 반대 방향인 이유.** 알림 푸시는 커밋 *후*로 미뤘는데 소켓 종료는 커밋 *전* 즉시 수행합니다. 실패 방향이 반대이기 때문입니다: 트랜잭션이 롤백됐는데 소켓을 끊었다면 클라이언트가 재연결하면 그만이지만, 커밋 후 콜백이 실행되지 않아 소켓이 살아남으면 무효화된 자격 증명이 계속 알림을 받습니다. 보안에서는 과하게 끊는 쪽이 안전합니다.

**프로덕션 영향 없음** — 레지스트리·데코레이터 모두 `@ConditionalOnProperty(app.websocket.enabled=true)` 게이트(기존 3개 클래스와 동일)이고, WS가 꺼진 구성에서는 `ObjectProvider`가 no-op입니다. `openapi3.yaml` 무변경.

## PR Checklist

- [x] 코드가 정상적으로 빌드되었나요? (`./gradlew build` 성공, spec 무변경)
- [x] 적절한 테스트 코드가 추가되었나요? 추가되었다면 아래에 어떤 테스트인지 설명해 주세요.
  - [x] `WebSocketSessionTerminationIntegrationTests` 3건 — **저장소 최초의 `RANDOM_PORT` + 실 HTTP + 실제 소켓 테스트**입니다. CSRF 프라이밍 → 실제 로그인으로 `session` 쿠키 획득 → SockJS raw websocket 경로로 연결(레지스트리가 전송 계층에 걸리므로 STOMP 프레임 불필요) 후:
    - 무효화가 대상 principal의 소켓만 1008로 끊고 **타 사용자 소켓은 유지** (키 격리 회귀)
    - 실제 호출 경로인 `changePassword` 로도 종료 검증
    - 정상 종료된 소켓은 레지스트리에서 제거되어 누수가 없고, 이후 무효화는 no-op
  - [x] 기존 `PasswordSessionInvalidationIntegrationTests`(HTTP 401 검증)에 역할 분담 javadoc 추가 — 두 테스트가 함께 "모든 자격 증명 무효화" 규칙을 채널 전체에서 지킵니다

- [ ] 리뷰어 설정이 완료되었나요?

## Other

### 참고사항

- 테스트 작성 중 확인: 세션 쿠키 이름은 `SESSION`이 아니라 **소문자 `session`**입니다(`application.yaml`의 `server.servlet.session.cookie.name`). AGENTS.md의 "SESSION 쿠키" 서술과 다르고, 기존 MockMvc 테스트는 서블릿 설정을 타지 않아 드러나지 않았습니다.
- 레지스트리는 인메모리라 **다중 인스턴스에서는 자기 인스턴스의 소켓만** 끊습니다. 현재 배포는 단일 인스턴스이고, 스케일아웃은 인메모리 STOMP 브로커와 같은 지점에서 함께 깨지므로 외부 브로커 도입 시 이 레지스트리도 같이 다뤄야 합니다(클래스 javadoc에 기록).
- 범위 밖(별건): 로그아웃 시 서버측 소켓 종료(현재 #221의 클라이언트측 `resetStompConnection`이 처리, principal 단위 종료는 다른 기기까지 끊어 과함), 세션 자연 만료 시 소켓 종료(만료 이벤트 부재로 별도 스윕 설계 필요).
